### PR TITLE
RPQ - TASK - SYS-08 | Adicionar nível de senioridade “Banco de Talentos”

### DIFF
--- a/app-modules/recruitment/lang/en/requisitions.php
+++ b/app-modules/recruitment/lang/en/requisitions.php
@@ -57,6 +57,9 @@ return [
         'c_level' => [
             'label' => 'C-Level',
         ],
+        'talent_pool' => [
+            'label' => 'Talent Pool',
+        ],
     ],
     'requisition_priority' => [
         'low' => [

--- a/app-modules/recruitment/lang/pt_BR/requisitions.php
+++ b/app-modules/recruitment/lang/pt_BR/requisitions.php
@@ -57,6 +57,9 @@ return [
         'c_level' => [
             'label' => 'C-Level',
         ],
+        'talent_pool' => [
+            'label' => 'Banco de Talentos',
+        ],
     ],
     'requisition_priority' => [
         'low' => [

--- a/app-modules/recruitment/src/Requisitions/Enums/ExperienceLevelEnum.php
+++ b/app-modules/recruitment/src/Requisitions/Enums/ExperienceLevelEnum.php
@@ -24,6 +24,7 @@ enum ExperienceLevelEnum: string implements HasColor, HasIcon, HasLabel
     case Manager = 'manager';
     case Head = 'head';
     case CLevel = 'c_level';
+    case TalentPool = 'talent_pool';
 
     public function getColor(): array
     {
@@ -35,6 +36,7 @@ enum ExperienceLevelEnum: string implements HasColor, HasIcon, HasLabel
             self::Specialist => Color::Teal,
             self::Coordinator, self::Manager => Color::Indigo,
             self::Head, self::CLevel => Color::Gray,
+            self::TalentPool => Color::Purple,
         };
     }
 
@@ -50,6 +52,7 @@ enum ExperienceLevelEnum: string implements HasColor, HasIcon, HasLabel
             self::Manager => Heroicon::BuildingOffice,
             self::Head => Heroicon::CommandLine,
             self::CLevel => Heroicon::Trophy,
+            self::TalentPool => Heroicon::Users,
         };
     }
 


### PR DESCRIPTION
This pull request adds support for a new "Talent Pool" experience level across the recruitment module. The changes include updating the `ExperienceLevelEnum` to include "Talent Pool", assigning it a color and icon, and providing translations for both English and Brazilian Portuguese.

**Experience Level Enum Enhancements:**

* Added `TalentPool` as a new case to the `ExperienceLevelEnum` enum in `ExperienceLevelEnum.php`.
* Assigned the color `Purple` to the new `TalentPool` experience level in the `getColor` method.
* Assigned the icon `Users` to the new `TalentPool` experience level in the `getIcon` method.

**Localization Updates:**

* Added the "Talent Pool" label to the English requisitions language file (`requisitions.php`).
* Added the "Banco de Talentos" label to the Brazilian Portuguese requisitions language file (`requisitions.php`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Talent Pool" as a new experience level option in recruitment
  * Included English and Portuguese (Brazil) translations ("Banco de Talentos")
  * Visual styling with purple color and users icon

<!-- end of auto-generated comment: release notes by coderabbit.ai -->