### PR TITLE
chore: handle nullable `end_date` for candidate work experience entries

### DIFF
--- a/app-modules/panel-app/src/Livewire/MyProfile/CandidateWorkExperience.php
+++ b/app-modules/panel-app/src/Livewire/MyProfile/CandidateWorkExperience.php
@@ -120,7 +120,7 @@ class CandidateWorkExperience extends MyProfileComponent
                     'company_name' => $entry['company_name'],
                     'description' => $entry['description'],
                     'start_date' => $entry['start_date'],
-                    'end_date' => $entry['end_date'],
+                    'end_date' => $entry['end_date'] ?? null,
                     'is_currently_working_here' => $entry['is_currently_working_here'] ?? false,
                 ]);
                 $existingIds[] = $experience->id;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Work experience entries can now be created without specifying an end date, supporting ongoing positions and improving consistency with the update process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->