### PR TITLE
chore: handle null default for `end_date` in CandidateEducation entries

### DIFF
--- a/app-modules/panel-app/src/Livewire/MyProfile/CandidateEducation.php
+++ b/app-modules/panel-app/src/Livewire/MyProfile/CandidateEducation.php
@@ -117,7 +117,7 @@ class CandidateEducation extends MyProfileComponent
                     'degree' => $entry['degree'],
                     'field_of_study' => $entry['field_of_study'],
                     'start_date' => $entry['start_date'],
-                    'end_date' => $entry['end_date'],
+                    'end_date' => $entry['end_date'] ?? null,
                     'is_enrolled' => $entry['is_enrolled'] ?? false,
                 ]);
                 $existingIds[] = $entry['id'];
@@ -127,7 +127,7 @@ class CandidateEducation extends MyProfileComponent
                     'degree' => $entry['degree'],
                     'field_of_study' => $entry['field_of_study'],
                     'start_date' => $entry['start_date'],
-                    'end_date' => $entry['end_date'],
+                    'end_date' => $entry['end_date'] ?? null,
                     'is_enrolled' => $entry['is_enrolled'] ?? false,
                 ]);
                 $existingIds[] = $education->id;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of missing end dates in candidate education records, which now properly store as null values when not provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->