### PR TITLE
chore: use `app()->isLocal()` instead of `!app()->isProduction()` in …

### DIFF
--- a/app-modules/panel-app/src/Filament/Pages/AppLoginPage.php
+++ b/app-modules/panel-app/src/Filament/Pages/AppLoginPage.php
@@ -20,7 +20,7 @@ final class AppLoginPage extends Login
     {
         parent::mount();
 
-        if (! app()->isProduction()) {
+        if (app()->isLocal()) {
             $this->form->fill([
                 'email' => 'admin@admin.com',
                 'password' => 'password',

--- a/app/Filament/Shared/Pages/LoginPage.php
+++ b/app/Filament/Shared/Pages/LoginPage.php
@@ -12,7 +12,7 @@ final class LoginPage extends Login
     {
         parent::mount();
 
-        if (! app()->isProduction()) {
+        if (app()->isLocal()) {
             $this->form->fill([
                 'email' => 'admin@admin.com',
                 'password' => 'password',


### PR DESCRIPTION
…login pages for clarity

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated login form auto-fill behavior on login pages to only activate in local development environments. Previously, test credentials were automatically populated in all non-production deployments; they now populate exclusively in local environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->