### PR TITLE
test(panel-app): add tests for AppDashboard, LandingPage 

### DIFF
--- a/app-modules/panel-app/tests/Feature/Filament/Pages/AppDashboardTest.php
+++ b/app-modules/panel-app/tests/Feature/Filament/Pages/AppDashboardTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\FilamentPanel;
+use He4rt\App\Filament\Pages\AppDashboard;
+use He4rt\App\Filament\Pages\LandingPage;
+use He4rt\Users\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    $this->user = User::factory()->create();
+    $this->user->refresh();
+    $this->user->candidate->update([
+        'is_onboarded' => true,
+        'onboarding_completed_at' => now(),
+    ]);
+
+    filament()->setCurrentPanel(FilamentPanel::App->value);
+});
+
+describe('Unauthenticated guest access', function (): void {
+    it('redirects guest to the landing page when accessing the dashboard', function (): void {
+        get(AppDashboard::getUrl())
+            ->assertRedirect(LandingPage::getUrl());
+    });
+});
+
+describe('Authenticated candidate access', function (): void {
+    it('renders the dashboard successfully for an authenticated candidate', function (): void {
+        actingAs($this->user);
+
+        get(AppDashboard::getUrl())
+            ->assertOk();
+    });
+
+    it('renders the dashboard Livewire component without errors', function (): void {
+        actingAs($this->user);
+
+        livewire(AppDashboard::class)
+            ->assertOk();
+    });
+});

--- a/app-modules/panel-app/tests/Feature/Filament/Pages/LandingPageTest.php
+++ b/app-modules/panel-app/tests/Feature/Filament/Pages/LandingPageTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\FilamentPanel;
+use He4rt\App\Filament\Pages\LandingPage;
+use He4rt\Users\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    filament()->setCurrentPanel(FilamentPanel::App->value);
+});
+
+describe('Public access to the landing page', function (): void {
+    it('renders the landing page for unauthenticated visitors', function (): void {
+        get(LandingPage::getUrl())
+            ->assertOk();
+    });
+
+    it('renders the landing page for authenticated users', function (): void {
+        actingAs(User::factory()->create());
+
+        get(LandingPage::getUrl())
+            ->assertOk();
+    });
+
+    it('renders the landing page Livewire component without errors', function (): void {
+        livewire(LandingPage::class)
+            ->assertOk();
+    });
+
+    it('does not register the landing page in the navigation', function (): void {
+        expect(LandingPage::shouldRegisterNavigation())->toBeFalse();
+    });
+});

--- a/app-modules/panel-app/tests/Feature/Filament/Widgets/UserTotalApplicationsTest.php
+++ b/app-modules/panel-app/tests/Feature/Filament/Widgets/UserTotalApplicationsTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\FilamentPanel;
+use He4rt\App\Filament\Widgets\UserTotalApplications;
+use He4rt\Applications\Enums\ApplicationStatusEnum;
+use He4rt\Applications\Models\Application;
+use He4rt\Users\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    $this->user = User::factory()->create();
+    $this->user->refresh();
+
+    $this->candidate = $this->user->candidate;
+
+    actingAs($this->user);
+    filament()->setCurrentPanel(FilamentPanel::App->value);
+});
+
+describe('Rendering', function (): void {
+    it('renders without errors', function (): void {
+        livewire(UserTotalApplications::class)
+            ->assertOk();
+    });
+
+    it('shows zero for all counts when the candidate has no applications', function (): void {
+        livewire(UserTotalApplications::class)
+            ->assertSeeInOrder([__('panel-app::filament.widgets.user_stats.total_applications'), '0'])
+            ->assertSeeInOrder([__('panel-app::filament.widgets.user_stats.active_applications'), '0'])
+            ->assertSeeInOrder([__('panel-app::filament.widgets.user_stats.offers_received'), '0']);
+    });
+});
+
+describe('Total applications count', function (): void {
+    it('counts all applications regardless of status', function (): void {
+        Application::factory()->create([
+            'candidate_id' => $this->candidate->getKey(),
+            'status' => ApplicationStatusEnum::New,
+        ]);
+        Application::factory()->create([
+            'candidate_id' => $this->candidate->getKey(),
+            'status' => ApplicationStatusEnum::Rejected,
+        ]);
+        Application::factory()->create([
+            'candidate_id' => $this->candidate->getKey(),
+            'status' => ApplicationStatusEnum::Hired,
+        ]);
+
+        livewire(UserTotalApplications::class)
+            ->assertSeeInOrder([__('panel-app::filament.widgets.user_stats.total_applications'), '3']);
+    });
+});
+
+describe('Active applications count', function (): void {
+    it('counts New, InReview, InProgress and OfferExtended as active', function (): void {
+        foreach ([
+            ApplicationStatusEnum::New,
+            ApplicationStatusEnum::InReview,
+            ApplicationStatusEnum::InProgress,
+            ApplicationStatusEnum::OfferExtended,
+        ] as $status) {
+            Application::factory()->create([
+                'candidate_id' => $this->candidate->getKey(),
+                'status' => $status,
+            ]);
+        }
+
+        livewire(UserTotalApplications::class)
+            ->assertSeeInOrder([__('panel-app::filament.widgets.user_stats.active_applications'), '4']);
+    });
+
+    it('does not count Rejected, Hired and Withdrawn as active', function (): void {
+        foreach ([
+            ApplicationStatusEnum::Rejected,
+            ApplicationStatusEnum::Hired,
+            ApplicationStatusEnum::Withdrawn,
+        ] as $status) {
+            Application::factory()->create([
+                'candidate_id' => $this->candidate->getKey(),
+                'status' => $status,
+            ]);
+        }
+
+        livewire(UserTotalApplications::class)
+            ->assertSeeInOrder([__('panel-app::filament.widgets.user_stats.active_applications'), '0']);
+    });
+});
+
+describe('Offers received count', function (): void {
+    it('counts OfferExtended, OfferAccepted and OfferDeclined as offers', function (): void {
+        foreach ([
+            ApplicationStatusEnum::OfferExtended,
+            ApplicationStatusEnum::OfferAccepted,
+            ApplicationStatusEnum::OfferDeclined,
+        ] as $status) {
+            Application::factory()->create([
+                'candidate_id' => $this->candidate->getKey(),
+                'status' => $status,
+            ]);
+        }
+
+        livewire(UserTotalApplications::class)
+            ->assertSeeInOrder([__('panel-app::filament.widgets.user_stats.offers_received'), '3']);
+    });
+
+    it('counts OfferExtended in both active and offers at the same time', function (): void {
+        Application::factory()->create([
+            'candidate_id' => $this->candidate->getKey(),
+            'status' => ApplicationStatusEnum::OfferExtended,
+        ]);
+
+        livewire(UserTotalApplications::class)
+            ->assertSeeInOrder([__('panel-app::filament.widgets.user_stats.active_applications'), '1'])
+            ->assertSeeInOrder([__('panel-app::filament.widgets.user_stats.offers_received'), '1']);
+    });
+});
+
+describe('User isolation', function (): void {
+    it('ignores applications from other users', function (): void {
+        $otherUser = User::factory()->create();
+        $otherUser->refresh();
+
+        Application::factory()->count(5)->create([
+            'candidate_id' => $otherUser->candidate->getKey(),
+            'status' => ApplicationStatusEnum::New,
+        ]);
+
+        livewire(UserTotalApplications::class)
+            ->assertSeeInOrder([__('panel-app::filament.widgets.user_stats.total_applications'), '0']);
+    });
+
+    it('counts only the authenticated user applications when multiple users exist', function (): void {
+        $otherUser = User::factory()->create();
+        $otherUser->refresh();
+
+        Application::factory()->count(2)->create([
+            'candidate_id' => $this->candidate->getKey(),
+            'status' => ApplicationStatusEnum::InReview,
+        ]);
+
+        Application::factory()->count(9)->create([
+            'candidate_id' => $otherUser->candidate->getKey(),
+            'status' => ApplicationStatusEnum::InReview,
+        ]);
+
+        livewire(UserTotalApplications::class)
+            ->assertSeeInOrder([__('panel-app::filament.widgets.user_stats.total_applications'), '2']);
+    });
+});


### PR DESCRIPTION
Resolve issue #133

This pull request adds comprehensive feature tests for key Filament pages and widgets in the panel app, focusing on access control, rendering, and business logic for user application statistics. The new tests ensure correct behavior for authenticated and unauthenticated users, and verify that application counts are accurate and user-specific.

**Feature tests for Filament pages:**

* Adds tests for the `AppDashboard` page to verify that unauthenticated users are redirected to the landing page, and that authenticated candidates can access and render the dashboard and its Livewire component without errors.
* Adds tests for the `LandingPage` to confirm it is accessible to both guests and authenticated users, its Livewire component renders correctly, and it is not registered in the navigation.

**Feature tests for user application statistics widget:**

* Adds detailed tests for the `UserTotalApplications` widget, covering rendering, correct counting of total, active, and offer-related applications, and ensuring isolation between users' data. The tests check various application statuses and confirm that only the authenticated user's applications are counted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added feature tests for dashboard access control, verifying authentication requirements and proper redirection of unauthenticated users to login flows.
  * Added comprehensive test coverage for landing page functionality, confirming successful rendering and proper accessibility across authenticated and unauthenticated user states.
  * Added extensive widget test suite validating application status categorization, offer counting logic, data isolation between users, and accurate count calculations for various statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->