### PR TITLE
test: admin panel resources

### DIFF
--- a/app-modules/panel-admin/tests/Feature/Filament/ApplicationResourceTest.php
+++ b/app-modules/panel-admin/tests/Feature/Filament/ApplicationResourceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Facades\Filament;
+use He4rt\Admin\Filament\Resources\Recruitment\Applications\Pages\EditApplication;
+use He4rt\Admin\Filament\Resources\Recruitment\Applications\Pages\ListApplications;
+use He4rt\Applications\Enums\ApplicationStatusEnum;
+use He4rt\Applications\Models\Application;
+use He4rt\Permissions\Roles;
+use He4rt\Users\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    actingAs(User::factory()->create());
+
+    auth()->user()->assignRole(Roles::SuperAdmin->value);
+});
+
+it('can list applications', function (): void {
+    $applications = Application::factory()->count(3)->create();
+
+    livewire(ListApplications::class)
+        ->assertCanSeeTableRecords($applications);
+});
+
+it('can render edit application page', function (): void {
+    $application = Application::factory()->create();
+
+    livewire(EditApplication::class, ['record' => $application->getRouteKey()])
+        ->assertOk();
+});
+
+it('can edit application status', function (): void {
+    $application = Application::factory()->create([
+        'status' => ApplicationStatusEnum::New,
+    ]);
+
+    livewire(EditApplication::class, ['record' => $application->getRouteKey()])
+        ->assertOk()
+        ->set('data.status', ApplicationStatusEnum::InReview->value)
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect($application->refresh()->status)->toBe(ApplicationStatusEnum::InReview);
+});

--- a/app-modules/panel-admin/tests/Feature/Filament/JobRequisition/EditJobRequisitionTest.php
+++ b/app-modules/panel-admin/tests/Feature/Filament/JobRequisition/EditJobRequisitionTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Facades\Filament;
+use He4rt\Admin\Filament\Resources\Recruitment\JobRequisitions\Pages\EditJobRequisition;
+use He4rt\Permissions\Roles;
+use He4rt\Recruitment\Requisitions\Enums\EmploymentTypeEnum;
+use He4rt\Recruitment\Requisitions\Enums\RequisitionStatusEnum;
+use He4rt\Recruitment\Requisitions\Enums\WorkArrangementEnum;
+use He4rt\Recruitment\Requisitions\Models\JobRequisition;
+use He4rt\Users\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    actingAs(User::factory()->create());
+
+    auth()->user()->assignRole(Roles::SuperAdmin->value);
+});
+
+it('can render edit job requisition page', function (): void {
+    $requisition = JobRequisition::factory()->create();
+
+    livewire(EditJobRequisition::class, ['record' => $requisition->getRouteKey()])
+        ->assertOk();
+});
+
+it('edit form is pre-populated with correct data', function (): void {
+    $requisition = JobRequisition::factory()->create([
+        'status' => RequisitionStatusEnum::Draft,
+        'work_arrangement' => WorkArrangementEnum::Remote,
+        'employment_type' => EmploymentTypeEnum::FullTimeEmployee,
+    ]);
+
+    livewire(EditJobRequisition::class, ['record' => $requisition->getRouteKey()])
+        ->assertFormSet([
+            'status' => RequisitionStatusEnum::Draft,
+            'work_arrangement' => WorkArrangementEnum::Remote,
+            'employment_type' => EmploymentTypeEnum::FullTimeEmployee,
+        ]);
+});

--- a/app-modules/panel-admin/tests/Feature/Filament/JobRequisition/ListJobRequisitionsTest.php
+++ b/app-modules/panel-admin/tests/Feature/Filament/JobRequisition/ListJobRequisitionsTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Facades\Filament;
+use He4rt\Admin\Filament\Resources\Recruitment\JobRequisitions\Pages\ListJobRequisitions;
+use He4rt\Permissions\Roles;
+use He4rt\Recruitment\Requisitions\Models\JobRequisition;
+use He4rt\Users\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    actingAs(User::factory()->create());
+
+    auth()->user()->assignRole(Roles::SuperAdmin->value);
+});
+
+it('can render list job requisitions page', function (): void {
+    livewire(ListJobRequisitions::class)
+        ->assertOk();
+});
+
+it('can list job requisitions', function (): void {
+    $requisitions = JobRequisition::factory()->count(5)->create();
+
+    livewire(ListJobRequisitions::class)
+        ->assertCanSeeTableRecords($requisitions);
+});

--- a/app-modules/panel-admin/tests/Feature/Filament/StageResourceTest.php
+++ b/app-modules/panel-admin/tests/Feature/Filament/StageResourceTest.php
@@ -39,7 +39,7 @@ it('validates required fields when editing stage', function (): void {
 
     livewire(EditStage::class, ['record' => $stage->getRouteKey()])
         ->set('data.name', '')
-        ->set('data.stage_type', null)
+        ->set('data.stage_type')
         ->call('save')
         ->assertHasFormErrors(['name', 'stage_type']);
 });

--- a/app-modules/panel-admin/tests/Feature/Filament/StageResourceTest.php
+++ b/app-modules/panel-admin/tests/Feature/Filament/StageResourceTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Facades\Filament;
+use He4rt\Admin\Filament\Resources\Recruitment\Stages\Pages\EditStage;
+use He4rt\Admin\Filament\Resources\Recruitment\Stages\Pages\ListStages;
+use He4rt\Permissions\Roles;
+use He4rt\Recruitment\Requisitions\Models\JobRequisition;
+use He4rt\Users\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    actingAs(User::factory()->create());
+
+    auth()->user()->assignRole(Roles::SuperAdmin->value);
+});
+
+it('cannot access list stages page directly', function (): void {
+    livewire(ListStages::class)
+        ->assertForbidden();
+});
+
+it('can render edit stage page', function (): void {
+    $requisition = JobRequisition::factory()->available()->create();
+    $stage = $requisition->stages->first();
+
+    livewire(EditStage::class, ['record' => $stage->getRouteKey()])
+        ->assertOk();
+});
+
+it('validates required fields when editing stage', function (): void {
+    $requisition = JobRequisition::factory()->available()->create();
+    $stage = $requisition->stages->first();
+
+    livewire(EditStage::class, ['record' => $stage->getRouteKey()])
+        ->set('data.name', '')
+        ->set('data.stage_type', null)
+        ->call('save')
+        ->assertHasFormErrors(['name', 'stage_type']);
+});
+
+it('validates expected_duration_days minimum value', function (): void {
+    $requisition = JobRequisition::factory()->available()->create();
+    $stage = $requisition->stages->first();
+
+    livewire(EditStage::class, ['record' => $stage->getRouteKey()])
+        ->set('data.expected_duration_days', 0)
+        ->call('save')
+        ->assertHasFormErrors(['expected_duration_days']);
+});


### PR DESCRIPTION
This pull request adds new feature tests for the admin panel's recruitment-related resources in the Filament interface. The tests cover listing, editing, and validating job requisitions, applications, and stages, ensuring the correct behavior and access control for these resources.

**Feature test additions and improvements:**

*Job Requisitions:*
- Added tests for listing job requisitions and verifying that the list page displays the correct records.
- Added tests for editing job requisitions, including checks that the edit form is pre-populated with the correct data.

*Applications:*
- Added tests for listing applications, rendering the edit application page, and editing the application status, verifying that status changes are correctly saved.

*Stages:*
- Added tests to ensure that direct access to the list stages page is forbidden, and that the edit stage page renders correctly.
- Added validation tests for required fields and minimum values when editing a stage, ensuring form validation works as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added feature tests for the admin panel covering application listing, editing, and status transitions.
  * Added tests for job requisition listing and edit forms, including pre-populated enum-backed fields.
  * Added tests for stage management: access control, edit page rendering, and form validation for required fields and numeric constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->