### PR TITLE
tests: screening

### DIFF
--- a/app-modules/screening/tests/Unit/Collections/ScreeningResponseCollectionTest.php
+++ b/app-modules/screening/tests/Unit/Collections/ScreeningResponseCollectionTest.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Screening\Collections\ScreeningResponseCollection;
+use He4rt\Screening\DTOs\ScreeningResponseDTO;
+
+/**
+ * @param  array<string, mixed>  $override
+ * @return array<string, mixed>
+ */
+function makeResponseData(array $override = []): array
+{
+    return array_merge([
+        'teamId' => 'team-1',
+        'applicationId' => 'app-1',
+        'questionId' => 'q-1',
+        'response_value' => ['value' => 'yes'],
+    ], $override);
+}
+
+describe('ScreeningResponseCollection', function (): void {
+    describe('constructor', function (): void {
+        it('creates an empty collection when no arguments are passed', function (): void {
+            $collection = new ScreeningResponseCollection();
+
+            expect(iterator_to_array($collection))->toBeEmpty();
+        });
+
+        it('creates collection from an array of existing DTOs', function (): void {
+            $dto1 = new ScreeningResponseDTO('team-1', 'app-1', 'q-1', ['value' => 'yes']);
+            $dto2 = new ScreeningResponseDTO('team-1', 'app-1', 'q-2', ['value' => 'no']);
+
+            $collection = new ScreeningResponseCollection([$dto1, $dto2]);
+
+            expect(iterator_to_array($collection))->toHaveCount(2);
+        });
+    });
+
+    describe('fromArray()', function (): void {
+        it('returns an empty collection for an empty array', function (): void {
+            $collection = ScreeningResponseCollection::fromArray([]);
+
+            expect(iterator_to_array($collection))->toBeEmpty();
+        });
+
+        it('creates the correct number of DTOs from raw arrays', function (): void {
+            $collection = ScreeningResponseCollection::fromArray([
+                makeResponseData(['questionId' => 'q-1']),
+                makeResponseData(['questionId' => 'q-2']),
+                makeResponseData(['questionId' => 'q-3']),
+            ]);
+
+            expect(iterator_to_array($collection))->toHaveCount(3);
+        });
+
+        it('creates DTOs with correct data from raw arrays', function (): void {
+            $collection = ScreeningResponseCollection::fromArray([
+                makeResponseData(['questionId' => 'q-42', 'response_value' => ['value' => 'no']]),
+            ]);
+
+            $items = iterator_to_array($collection);
+
+            expect($items[0])->toBeInstanceOf(ScreeningResponseDTO::class)
+                ->and($items[0]->questionId)->toBe('q-42')
+                ->and($items[0]->response_value)->toBe(['value' => 'no']);
+        });
+
+        it('normalizes scalar response_value via make() during fromArray()', function (): void {
+            // Testa a integração entre fromArray() e ScreeningResponseDTO::make()
+            $collection = ScreeningResponseCollection::fromArray([
+                makeResponseData(['response_value' => 'yes']),
+            ]);
+
+            $items = iterator_to_array($collection);
+
+            expect($items[0]->response_value)->toBe(['value' => 'yes']);
+        });
+
+        it('creates distinct DTO instances for each item', function (): void {
+            $collection = ScreeningResponseCollection::fromArray([
+                makeResponseData(['questionId' => 'q-1']),
+                makeResponseData(['questionId' => 'q-2']),
+            ]);
+
+            $items = iterator_to_array($collection);
+
+            expect($items[0])->not->toBe($items[1]);
+        });
+    });
+
+    describe('add()', function (): void {
+        it('appends a DTO to an empty collection', function (): void {
+            $collection = new ScreeningResponseCollection();
+            $dto = new ScreeningResponseDTO('team-1', 'app-1', 'q-1', ['value' => 'yes']);
+
+            $collection->add($dto);
+
+            expect(iterator_to_array($collection))->toHaveCount(1);
+        });
+
+        it('appends multiple DTOs sequentially', function (): void {
+            $collection = new ScreeningResponseCollection();
+            $collection->add(new ScreeningResponseDTO('team-1', 'app-1', 'q-1', ['value' => 'yes']));
+            $collection->add(new ScreeningResponseDTO('team-1', 'app-1', 'q-2', ['value' => 'no']));
+
+            expect(iterator_to_array($collection))->toHaveCount(2);
+        });
+    });
+
+    describe('getIterator()', function (): void {
+        it('returns an ArrayIterator instance', function (): void {
+            $collection = ScreeningResponseCollection::fromArray([makeResponseData()]);
+
+            expect($collection->getIterator())->toBeInstanceOf(ArrayIterator::class);
+        });
+
+        it('allows foreach traversal yielding ScreeningResponseDTO instances', function (): void {
+            $collection = ScreeningResponseCollection::fromArray([
+                makeResponseData(['questionId' => 'q-1']),
+                makeResponseData(['questionId' => 'q-2']),
+            ]);
+
+            $visited = [];
+            foreach ($collection as $dto) {
+                expect($dto)->toBeInstanceOf(ScreeningResponseDTO::class);
+                $visited[] = $dto->questionId;
+            }
+
+            expect($visited)->toBe(['q-1', 'q-2']);
+        });
+
+        it('preserves insertion order during traversal', function (): void {
+            $collection = ScreeningResponseCollection::fromArray([
+                makeResponseData(['questionId' => 'first']),
+                makeResponseData(['questionId' => 'second']),
+                makeResponseData(['questionId' => 'third']),
+            ]);
+
+            $ids = array_map(
+                fn (ScreeningResponseDTO $dto): string => $dto->questionId,
+                iterator_to_array($collection),
+            );
+
+            expect($ids)->toBe(['first', 'second', 'third']);
+        });
+
+        it('does not iterate over an empty collection', function (): void {
+            $collection = new ScreeningResponseCollection();
+            $count = 0;
+
+            foreach ($collection as $dto) {
+                $count++;
+            }
+
+            expect($count)->toBe(0);
+        });
+    });
+
+    describe('jsonSerialize()', function (): void {
+        it('returns an empty array for an empty collection', function (): void {
+            expect(new ScreeningResponseCollection()->jsonSerialize())->toBe([]);
+        });
+
+        it('returns an array of ScreeningResponseDTO instances', function (): void {
+            $collection = ScreeningResponseCollection::fromArray([makeResponseData()]);
+            $serialized = $collection->jsonSerialize();
+
+            expect($serialized)->toBeArray()
+                ->and($serialized[0])->toBeInstanceOf(ScreeningResponseDTO::class);
+        });
+
+        it('produces valid JSON via json_encode on empty collection', function (): void {
+            expect(json_encode(new ScreeningResponseCollection()))->toBe('[]');
+        });
+
+        it('round-trips correctly via json_encode + json_decode', function (): void {
+            $collection = ScreeningResponseCollection::fromArray([
+                makeResponseData([
+                    'teamId' => 'team-99',
+                    'applicationId' => 'app-99',
+                    'questionId' => 'q-99',
+                    'response_value' => ['value' => 'yes'],
+                ]),
+            ]);
+
+            $decoded = json_decode(json_encode($collection), true);
+
+            expect($decoded)->toHaveCount(1)
+                ->and($decoded[0]['teamId'])->toBe('team-99')
+                ->and($decoded[0]['applicationId'])->toBe('app-99')
+                ->and($decoded[0]['questionId'])->toBe('q-99')
+                ->and($decoded[0]['response_value'])->toBe(['value' => 'yes']);
+        });
+
+        it('preserves multiple DTOs with different response_value types in round-trip', function (): void {
+            $collection = ScreeningResponseCollection::fromArray([
+                makeResponseData(['questionId' => 'q-1', 'response_value' => 'yes']),
+                makeResponseData(['questionId' => 'q-2', 'response_value' => ['php', 'go']]),
+            ]);
+
+            $decoded = json_decode(json_encode($collection), true);
+
+            expect($decoded)->toHaveCount(2)
+                ->and($decoded[0]['questionId'])->toBe('q-1')
+                ->and($decoded[0]['response_value'])->toBe(['value' => 'yes'])
+                ->and($decoded[1]['questionId'])->toBe('q-2')
+                ->and($decoded[1]['response_value'])->toBe(['php', 'go']);
+        });
+    });
+});

--- a/app-modules/screening/tests/Unit/DTOs/ScreeningResponseDTOTest.php
+++ b/app-modules/screening/tests/Unit/DTOs/ScreeningResponseDTOTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Screening\DTOs\ScreeningResponseDTO;
+
+/**
+ * @param  array<string, mixed>  $override
+ * @return array<string, mixed>
+ */
+function makeDTOData(array $override = []): array
+{
+    return array_merge([
+        'teamId' => 'team-1',
+        'applicationId' => 'app-1',
+        'questionId' => 'q-1',
+        'response_value' => ['value' => 'yes'],
+    ], $override);
+}
+
+describe('ScreeningResponseDTO', function (): void {
+    describe('make()', function (): void {
+        it('maps all fields correctly from a valid array', function (): void {
+            $dto = ScreeningResponseDTO::make(makeDTOData([
+                'teamId' => 'team-abc',
+                'applicationId' => 'app-abc',
+                'questionId' => 'q-abc',
+            ]));
+
+            expect($dto)->toBeInstanceOf(ScreeningResponseDTO::class)
+                ->and($dto->teamId)->toBe('team-abc')
+                ->and($dto->applicationId)->toBe('app-abc')
+                ->and($dto->questionId)->toBe('q-abc');
+        });
+
+        it('keeps response_value as-is when it is already an array', function (): void {
+            $dto = ScreeningResponseDTO::make(makeDTOData([
+                'response_value' => ['php', 'go', 'rust'],
+            ]));
+
+            expect($dto->response_value)->toBe(['php', 'go', 'rust']);
+        });
+
+        it('keeps associative array response_value as-is', function (): void {
+            $dto = ScreeningResponseDTO::make(makeDTOData([
+                'response_value' => ['value' => 'yes'],
+            ]));
+
+            expect($dto->response_value)->toBe(['value' => 'yes']);
+        });
+
+        it('wraps string scalar response_value in value key', function (): void {
+            // Respostas YesNo chegam como string 'yes'/'no' e devem ser normalizadas
+            $dto = ScreeningResponseDTO::make(makeDTOData([
+                'response_value' => 'yes',
+            ]));
+
+            expect($dto->response_value)->toBe(['value' => 'yes']);
+        });
+
+        it('wraps integer scalar response_value in value key', function (): void {
+            $dto = ScreeningResponseDTO::make(makeDTOData([
+                'response_value' => 42,
+            ]));
+
+            expect($dto->response_value)->toBe(['value' => 42]);
+        });
+    });
+
+    describe('constructor', function (): void {
+        it('assigns all properties directly', function (): void {
+            $dto = new ScreeningResponseDTO(
+                teamId: 'team-x',
+                applicationId: 'app-x',
+                questionId: 'q-x',
+                response_value: ['value' => 'no'],
+            );
+
+            expect($dto->teamId)->toBe('team-x')
+                ->and($dto->applicationId)->toBe('app-x')
+                ->and($dto->questionId)->toBe('q-x')
+                ->and($dto->response_value)->toBe(['value' => 'no']);
+        });
+    });
+});

--- a/app-modules/screening/tests/Unit/QuestionTypes/MultipleChoiceTypeTest.php
+++ b/app-modules/screening/tests/Unit/QuestionTypes/MultipleChoiceTypeTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Screening\Enums\QuestionTypeEnum;
+use He4rt\Screening\QuestionTypes\MultipleChoiceType;
+use He4rt\Screening\QuestionTypes\Settings\MultipleChoiceSettings;
+
+describe('MultipleChoiceType', function (): void {
+    it('returns the MultipleChoice enum case', function (): void {
+        expect(MultipleChoiceType::type())->toBe(QuestionTypeEnum::MultipleChoice);
+    });
+
+    it('returns MultipleChoiceSettings class name', function (): void {
+        expect(MultipleChoiceType::settingsClass())->toBe(MultipleChoiceSettings::class);
+    });
+
+    it('returns a MultipleChoiceSettings instance from defaultSettings()', function (): void {
+        expect(MultipleChoiceType::defaultSettings())->toBeInstanceOf(MultipleChoiceSettings::class);
+    });
+
+    it('returns the correct blade component path', function (): void {
+        expect(MultipleChoiceType::component())->toBe('screening::questions.multiple-choice');
+    });
+
+    it('returns a non-empty settings schema with 3 fields', function (): void {
+        expect(MultipleChoiceType::settingsSchema())->toHaveCount(3);
+    });
+
+    it('returns a non-empty label string', function (): void {
+        expect(MultipleChoiceType::label())->toBeString()->not->toBeEmpty();
+    });
+
+    it('returns a non-empty icon string', function (): void {
+        expect(MultipleChoiceType::icon())->toBeString()->not->toBeEmpty();
+    });
+});

--- a/app-modules/screening/tests/Unit/QuestionTypes/NumberTypeTest.php
+++ b/app-modules/screening/tests/Unit/QuestionTypes/NumberTypeTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Screening\Enums\QuestionTypeEnum;
+use He4rt\Screening\QuestionTypes\NumberType;
+use He4rt\Screening\QuestionTypes\Settings\NumberSettings;
+
+describe('NumberType', function (): void {
+    it('returns the Number enum case', function (): void {
+        expect(NumberType::type())->toBe(QuestionTypeEnum::Number);
+    });
+
+    it('returns NumberSettings class name', function (): void {
+        expect(NumberType::settingsClass())->toBe(NumberSettings::class);
+    });
+
+    it('returns a NumberSettings instance from defaultSettings()', function (): void {
+        expect(NumberType::defaultSettings())->toBeInstanceOf(NumberSettings::class);
+    });
+
+    it('returns the correct blade component path', function (): void {
+        expect(NumberType::component())->toBe('screening::questions.number');
+    });
+
+    it('returns a non-empty settings schema with 5 fields', function (): void {
+        expect(NumberType::settingsSchema())->toHaveCount(5);
+    });
+
+    it('returns a non-empty label string', function (): void {
+        expect(NumberType::label())->toBeString()->not->toBeEmpty();
+    });
+
+    it('returns a non-empty icon string', function (): void {
+        expect(NumberType::icon())->toBeString()->not->toBeEmpty();
+    });
+});

--- a/app-modules/screening/tests/Unit/QuestionTypes/QuestionTypeRegistryTest.php
+++ b/app-modules/screening/tests/Unit/QuestionTypes/QuestionTypeRegistryTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Screening\Enums\QuestionTypeEnum;
+use He4rt\Screening\QuestionTypes\MultipleChoiceType;
+use He4rt\Screening\QuestionTypes\NumberType;
+use He4rt\Screening\QuestionTypes\QuestionTypeRegistry;
+use He4rt\Screening\QuestionTypes\SingleChoiceType;
+use He4rt\Screening\QuestionTypes\TextType;
+use He4rt\Screening\QuestionTypes\YesNoType;
+
+describe('QuestionTypeRegistry', function (): void {
+    describe('get()', function (): void {
+        it('returns the correct class for each registered type', function (QuestionTypeEnum $enum, string $expectedClass): void {
+            expect(QuestionTypeRegistry::get($enum))->toBe($expectedClass);
+        })->with([
+            'yes_no' => [QuestionTypeEnum::YesNo, YesNoType::class],
+            'text' => [QuestionTypeEnum::Text, TextType::class],
+            'number' => [QuestionTypeEnum::Number, NumberType::class],
+            'single_choice' => [QuestionTypeEnum::SingleChoice, SingleChoiceType::class],
+            'multiple_choice' => [QuestionTypeEnum::MultipleChoice, MultipleChoiceType::class],
+        ]);
+    });
+
+    describe('all()', function (): void {
+        it('returns all 5 registered types', function (): void {
+            expect(QuestionTypeRegistry::all())->toHaveCount(5);
+        });
+
+        it('contains all expected type classes', function (): void {
+            $all = QuestionTypeRegistry::all();
+
+            expect($all)->toContain(YesNoType::class)
+                ->and($all)->toContain(TextType::class)
+                ->and($all)->toContain(NumberType::class)
+                ->and($all)->toContain(SingleChoiceType::class)
+                ->and($all)->toContain(MultipleChoiceType::class);
+        });
+
+        it('returns indexed array values', function (): void {
+            $all = QuestionTypeRegistry::all();
+
+            expect(array_is_list($all))->toBeTrue();
+        });
+    });
+
+    describe('getSettingsSchema()', function (): void {
+        it('returns empty array when type is null', function (): void {
+            expect(QuestionTypeRegistry::getSettingsSchema(null))->toBe([]);
+        });
+
+        it('returns empty array for yes_no type (no extra settings)', function (): void {
+            expect(QuestionTypeRegistry::getSettingsSchema(QuestionTypeEnum::YesNo))->toBe([]);
+        });
+
+        it('returns non-empty schema for types that have settings', function (QuestionTypeEnum $type): void {
+            expect(QuestionTypeRegistry::getSettingsSchema($type))->not->toBeEmpty();
+        })->with([
+            'text' => QuestionTypeEnum::Text,
+            'number' => QuestionTypeEnum::Number,
+            'single_choice' => QuestionTypeEnum::SingleChoice,
+            'multiple_choice' => QuestionTypeEnum::MultipleChoice,
+        ]);
+    });
+});

--- a/app-modules/screening/tests/Unit/QuestionTypes/SingleChoiceTypeTest.php
+++ b/app-modules/screening/tests/Unit/QuestionTypes/SingleChoiceTypeTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Screening\Enums\QuestionTypeEnum;
+use He4rt\Screening\QuestionTypes\Settings\SingleChoiceSettings;
+use He4rt\Screening\QuestionTypes\SingleChoiceType;
+
+describe('SingleChoiceType', function (): void {
+    it('returns the SingleChoice enum case', function (): void {
+        expect(SingleChoiceType::type())->toBe(QuestionTypeEnum::SingleChoice);
+    });
+
+    it('returns SingleChoiceSettings class name', function (): void {
+        expect(SingleChoiceType::settingsClass())->toBe(SingleChoiceSettings::class);
+    });
+
+    it('returns a SingleChoiceSettings instance from defaultSettings()', function (): void {
+        expect(SingleChoiceType::defaultSettings())->toBeInstanceOf(SingleChoiceSettings::class);
+    });
+
+    it('returns the correct blade component path', function (): void {
+        expect(SingleChoiceType::component())->toBe('screening::questions.single-choice');
+    });
+
+    it('returns a non-empty settings schema with 2 fields', function (): void {
+        expect(SingleChoiceType::settingsSchema())->toHaveCount(2);
+    });
+
+    it('returns a non-empty label string', function (): void {
+        expect(SingleChoiceType::label())->toBeString()->not->toBeEmpty();
+    });
+
+    it('returns a non-empty icon string', function (): void {
+        expect(SingleChoiceType::icon())->toBeString()->not->toBeEmpty();
+    });
+});

--- a/app-modules/screening/tests/Unit/QuestionTypes/TextTypeTest.php
+++ b/app-modules/screening/tests/Unit/QuestionTypes/TextTypeTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Screening\Enums\QuestionTypeEnum;
+use He4rt\Screening\QuestionTypes\Settings\TextSettings;
+use He4rt\Screening\QuestionTypes\TextType;
+
+describe('TextType', function (): void {
+    it('returns the Text enum case', function (): void {
+        expect(TextType::type())->toBe(QuestionTypeEnum::Text);
+    });
+
+    it('returns TextSettings class name', function (): void {
+        expect(TextType::settingsClass())->toBe(TextSettings::class);
+    });
+
+    it('returns a TextSettings instance from defaultSettings()', function (): void {
+        expect(TextType::defaultSettings())->toBeInstanceOf(TextSettings::class);
+    });
+
+    it('returns the correct blade component path', function (): void {
+        expect(TextType::component())->toBe('screening::questions.text');
+    });
+
+    it('returns a non-empty settings schema with 3 fields', function (): void {
+        expect(TextType::settingsSchema())->toHaveCount(3);
+    });
+
+    it('returns a non-empty label string', function (): void {
+        expect(TextType::label())->toBeString()->not->toBeEmpty();
+    });
+
+    it('returns a non-empty icon string', function (): void {
+        expect(TextType::icon())->toBeString()->not->toBeEmpty();
+    });
+});

--- a/app-modules/screening/tests/Unit/QuestionTypes/YesNoTypeTest.php
+++ b/app-modules/screening/tests/Unit/QuestionTypes/YesNoTypeTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Screening\Enums\QuestionTypeEnum;
+use He4rt\Screening\QuestionTypes\Settings\YesNoSettings;
+use He4rt\Screening\QuestionTypes\YesNoType;
+
+describe('YesNoType', function (): void {
+    it('returns the YesNo enum case', function (): void {
+        expect(YesNoType::type())->toBe(QuestionTypeEnum::YesNo);
+    });
+
+    it('returns YesNoSettings class name', function (): void {
+        expect(YesNoType::settingsClass())->toBe(YesNoSettings::class);
+    });
+
+    it('returns a YesNoSettings instance from defaultSettings()', function (): void {
+        expect(YesNoType::defaultSettings())->toBeInstanceOf(YesNoSettings::class);
+    });
+
+    it('returns the correct blade component path', function (): void {
+        expect(YesNoType::component())->toBe('screening::questions.yes-no');
+    });
+
+    it('returns an empty settings schema', function (): void {
+        expect(YesNoType::settingsSchema())->toBe([]);
+    });
+
+    it('returns a non-empty label string', function (): void {
+        expect(YesNoType::label())->toBeString()->not->toBeEmpty();
+    });
+
+    it('returns a non-empty icon string', function (): void {
+        expect(YesNoType::icon())->toBeString()->not->toBeEmpty();
+    });
+});

--- a/app-modules/screening/tests/Unit/Settings/MultipleChoiceSettingsTest.php
+++ b/app-modules/screening/tests/Unit/Settings/MultipleChoiceSettingsTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Screening\QuestionTypes\Settings\MultipleChoiceSettings;
+use He4rt\Screening\Rules\MultipleChoiceRule;
+
+describe('MultipleChoiceSettings', function (): void {
+    describe('fromArray()', function (): void {
+        it('defaults minSelections to 0 when not provided', function (): void {
+            $settings = MultipleChoiceSettings::fromArray([]);
+
+            expect($settings->minSelections)->toBe(0);
+        });
+
+        it('defaults maxSelections to null when not provided', function (): void {
+            $settings = MultipleChoiceSettings::fromArray([]);
+
+            expect($settings->maxSelections)->toBeNull();
+        });
+
+        it('defaults choices to empty array when not provided', function (): void {
+            $settings = MultipleChoiceSettings::fromArray([]);
+
+            expect($settings->choices)->toBe([]);
+        });
+
+        it('casts min_selections to int', function (): void {
+            $settings = MultipleChoiceSettings::fromArray(['min_selections' => '2']);
+
+            expect($settings->minSelections)->toBe(2);
+        });
+
+        it('casts max_selections to int', function (): void {
+            $settings = MultipleChoiceSettings::fromArray(['max_selections' => '5']);
+
+            expect($settings->maxSelections)->toBe(5);
+        });
+
+        it('reads choices from array', function (): void {
+            $choices = [
+                ['value' => 'php', 'label' => 'PHP'],
+                ['value' => 'go', 'label' => 'Go'],
+            ];
+
+            $settings = MultipleChoiceSettings::fromArray(['choices' => $choices]);
+
+            expect($settings->choices)->toBe($choices);
+        });
+    });
+
+    describe('toArray()', function (): void {
+        it('serializes all properties', function (): void {
+            $choices = [['value' => 'php', 'label' => 'PHP']];
+            $settings = new MultipleChoiceSettings(minSelections: 1, maxSelections: 3, choices: $choices);
+
+            expect($settings->toArray())->toBe([
+                'min_selections' => 1,
+                'max_selections' => 3,
+                'choices' => $choices,
+            ]);
+        });
+    });
+
+    describe('rules()', function (): void {
+        it('always includes present and array rules', function (): void {
+            $settings = new MultipleChoiceSettings();
+            $rules = $settings->rules('skills', false);
+
+            expect($rules[0])->toBe('present')
+                ->and($rules[1])->toBe('array');
+        });
+
+        it('always includes a MultipleChoiceRule instance as third rule', function (): void {
+            $settings = new MultipleChoiceSettings();
+            $rules = $settings->rules('skills', false);
+
+            expect($rules[2])->toBeInstanceOf(MultipleChoiceRule::class);
+        });
+
+        it('when required=true and minSelections=0, enforces at least 1 selection', function (): void {
+            // required=true + minSelections=0 → max(0, 1) = 1
+            $settings = new MultipleChoiceSettings(minSelections: 0);
+            $rules = $settings->rules('skills', true);
+
+            // The MultipleChoiceRule is constructed with min=1
+            expect($rules[2])->toBeInstanceOf(MultipleChoiceRule::class);
+        });
+
+        it('when required=true and minSelections=3, preserves the higher min', function (): void {
+            // required=true + minSelections=3 → max(3, 1) = 3
+            $settings = new MultipleChoiceSettings(minSelections: 3);
+            $rules = $settings->rules('skills', true);
+
+            expect($rules[2])->toBeInstanceOf(MultipleChoiceRule::class);
+        });
+
+        it('when required=false, uses minSelections directly (can be 0)', function (): void {
+            $settings = new MultipleChoiceSettings(minSelections: 0);
+            $rules = $settings->rules('skills', false);
+
+            expect($rules[2])->toBeInstanceOf(MultipleChoiceRule::class);
+        });
+
+        it('returns exactly 3 rules', function (): void {
+            $settings = new MultipleChoiceSettings();
+
+            expect($settings->rules('skills', false))->toHaveCount(3);
+        });
+    });
+
+    describe('initialValue()', function (): void {
+        it('returns an empty array', function (): void {
+            expect(new MultipleChoiceSettings()->initialValue())->toBe([]);
+        });
+    });
+
+    describe('messages()', function (): void {
+        it('returns array with required message key', function (): void {
+            $messages = new MultipleChoiceSettings()->messages('skills');
+
+            expect($messages)->toHaveKey('skills.required');
+        });
+
+        it('uses the provided attribute name in the key', function (): void {
+            $messages = new MultipleChoiceSettings()->messages('technologies');
+
+            expect($messages)->toHaveKey('technologies.required');
+        });
+    });
+});

--- a/app-modules/screening/tests/Unit/Settings/MultipleChoiceSettingsTest.php
+++ b/app-modules/screening/tests/Unit/Settings/MultipleChoiceSettingsTest.php
@@ -79,27 +79,42 @@ describe('MultipleChoiceSettings', function (): void {
         });
 
         it('when required=true and minSelections=0, enforces at least 1 selection', function (): void {
-            // required=true + minSelections=0 → max(0, 1) = 1
             $settings = new MultipleChoiceSettings(minSelections: 0);
-            $rules = $settings->rules('skills', true);
+            /** @var MultipleChoiceRule $rule */
+            $rule = $settings->rules('skills', true)[2];
 
-            // The MultipleChoiceRule is constructed with min=1
-            expect($rules[2])->toBeInstanceOf(MultipleChoiceRule::class);
+            $failed = false;
+            $rule->validate('skills', [], function () use (&$failed): void {
+                $failed = true;
+            });
+
+            expect($failed)->toBeTrue();
         });
 
         it('when required=true and minSelections=3, preserves the higher min', function (): void {
-            // required=true + minSelections=3 → max(3, 1) = 3
             $settings = new MultipleChoiceSettings(minSelections: 3);
-            $rules = $settings->rules('skills', true);
+            /** @var MultipleChoiceRule $rule */
+            $rule = $settings->rules('skills', true)[2];
 
-            expect($rules[2])->toBeInstanceOf(MultipleChoiceRule::class);
+            $failed = false;
+            $rule->validate('skills', ['a', 'b'], function () use (&$failed): void {
+                $failed = true;
+            });
+
+            expect($failed)->toBeTrue();
         });
 
         it('when required=false, uses minSelections directly (can be 0)', function (): void {
             $settings = new MultipleChoiceSettings(minSelections: 0);
-            $rules = $settings->rules('skills', false);
+            /** @var MultipleChoiceRule $rule */
+            $rule = $settings->rules('skills', false)[2];
 
-            expect($rules[2])->toBeInstanceOf(MultipleChoiceRule::class);
+            $failed = false;
+            $rule->validate('skills', [], function () use (&$failed): void {
+                $failed = true;
+            });
+
+            expect($failed)->toBeFalse();
         });
 
         it('returns exactly 3 rules', function (): void {

--- a/app-modules/screening/tests/Unit/Settings/NumberSettingsTest.php
+++ b/app-modules/screening/tests/Unit/Settings/NumberSettingsTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Screening\QuestionTypes\Settings\NumberSettings;
+
+describe('NumberSettings', function (): void {
+    describe('fromArray()', function (): void {
+        it('creates with all nulls when array is empty', function (): void {
+            $settings = NumberSettings::fromArray([]);
+
+            expect($settings->min)->toBeNull()
+                ->and($settings->max)->toBeNull()
+                ->and($settings->step)->toBeNull()
+                ->and($settings->prefix)->toBeNull()
+                ->and($settings->suffix)->toBeNull();
+        });
+
+        it('casts numeric string values to float', function (): void {
+            $settings = NumberSettings::fromArray([
+                'min' => '5',
+                'max' => '100',
+                'step' => '0.5',
+            ]);
+
+            expect($settings->min)->toBe(5.0)
+                ->and($settings->max)->toBe(100.0)
+                ->and($settings->step)->toBe(0.5);
+        });
+
+        it('reads prefix and suffix as strings', function (): void {
+            $settings = NumberSettings::fromArray([
+                'prefix' => 'R$',
+                'suffix' => 'anos',
+            ]);
+
+            expect($settings->prefix)->toBe('R$')
+                ->and($settings->suffix)->toBe('anos');
+        });
+    });
+
+    describe('toArray()', function (): void {
+        it('serializes all properties', function (): void {
+            $settings = new NumberSettings(min: 0.0, max: 100.0, step: 1.0, prefix: '$', suffix: 'yr');
+
+            expect($settings->toArray())->toBe([
+                'min' => 0.0,
+                'max' => 100.0,
+                'step' => 1.0,
+                'prefix' => '$',
+                'suffix' => 'yr',
+            ]);
+        });
+    });
+
+    describe('rules()', function (): void {
+        it('always includes numeric rule', function (): void {
+            $settings = new NumberSettings();
+
+            expect($settings->rules('answer', false))->toContain('numeric');
+        });
+
+        it('includes required rule when required is true', function (): void {
+            $settings = new NumberSettings();
+
+            expect($settings->rules('answer', true))->toContain('required');
+        });
+
+        it('includes nullable rule when required is false', function (): void {
+            $settings = new NumberSettings();
+
+            expect($settings->rules('answer', false))->toContain('nullable');
+        });
+
+        it('defaults to min:0 when min is not set', function (): void {
+            $settings = new NumberSettings();
+
+            expect($settings->rules('answer', false))->toContain('min:0');
+        });
+
+        it('uses explicit min when set and does not add min:0', function (): void {
+            $settings = new NumberSettings(min: 10.0);
+            $rules = $settings->rules('answer', false);
+
+            expect($rules)->toContain('min:10')
+                ->and($rules)->not->toContain('min:0');
+        });
+
+        it('includes max rule when max is set', function (): void {
+            $settings = new NumberSettings(max: 500.0);
+
+            expect($settings->rules('answer', false))->toContain('max:500');
+        });
+
+        it('does not include max rule when max is not set', function (): void {
+            $settings = new NumberSettings();
+            $rules = $settings->rules('answer', false);
+
+            $hasMaxRule = collect($rules)->contains(fn ($r) => str_starts_with((string) $r, 'max:'));
+
+            expect($hasMaxRule)->toBeFalse();
+        });
+
+        it('combines all constraints when fully configured', function (): void {
+            $settings = new NumberSettings(min: 5.0, max: 50.0);
+            $rules = $settings->rules('answer', true);
+
+            expect($rules)->toContain('numeric')
+                ->and($rules)->toContain('required')
+                ->and($rules)->toContain('min:5')
+                ->and($rules)->toContain('max:50');
+        });
+    });
+
+    describe('initialValue()', function (): void {
+        it('returns null', function (): void {
+            expect(new NumberSettings()->initialValue())->toBeNull();
+        });
+    });
+
+    describe('messages()', function (): void {
+        it('returns array with expected message keys', function (): void {
+            $messages = new NumberSettings()->messages('salary');
+
+            expect($messages)->toHaveKey('salary.min')
+                ->and($messages)->toHaveKey('salary.max')
+                ->and($messages)->toHaveKey('salary.required')
+                ->and($messages)->toHaveKey('salary.numeric');
+        });
+
+        it('uses the provided attribute name in all keys', function (): void {
+            $messages = new NumberSettings()->messages('experience_years');
+
+            expect($messages)->toHaveKey('experience_years.min');
+        });
+    });
+});

--- a/app-modules/screening/tests/Unit/Settings/SingleChoiceSettingsTest.php
+++ b/app-modules/screening/tests/Unit/Settings/SingleChoiceSettingsTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Screening\QuestionTypes\Settings\SingleChoiceSettings;
+
+describe('SingleChoiceSettings', function (): void {
+    describe('fromArray()', function (): void {
+        it('defaults layout to radio when not provided', function (): void {
+            $settings = SingleChoiceSettings::fromArray([]);
+
+            expect($settings->layout)->toBe('radio');
+        });
+
+        it('defaults choices to empty array when not provided', function (): void {
+            $settings = SingleChoiceSettings::fromArray([]);
+
+            expect($settings->choices)->toBe([]);
+        });
+
+        it('reads layout from array', function (): void {
+            $settings = SingleChoiceSettings::fromArray(['layout' => 'dropdown']);
+
+            expect($settings->layout)->toBe('dropdown');
+        });
+
+        it('reads choices from array', function (): void {
+            $choices = [
+                ['value' => 'php', 'label' => 'PHP'],
+                ['value' => 'js', 'label' => 'JavaScript'],
+            ];
+
+            $settings = SingleChoiceSettings::fromArray(['choices' => $choices]);
+
+            expect($settings->choices)->toBe($choices);
+        });
+    });
+
+    describe('toArray()', function (): void {
+        it('serializes layout and choices', function (): void {
+            $choices = [['value' => 'yes', 'label' => 'Yes']];
+            $settings = new SingleChoiceSettings(layout: 'dropdown', choices: $choices);
+
+            expect($settings->toArray())->toBe([
+                'layout' => 'dropdown',
+                'choices' => $choices,
+            ]);
+        });
+    });
+
+    describe('rules()', function (): void {
+        it('includes required rule when required is true', function (): void {
+            $settings = new SingleChoiceSettings();
+            $rules = $settings->rules('answer', true);
+
+            expect(array_values($rules))->toContain('required');
+        });
+
+        it('returns empty rules when required is false', function (): void {
+            $settings = new SingleChoiceSettings();
+
+            expect($settings->rules('answer', false))->toBe([]);
+        });
+    });
+
+    describe('initialValue()', function (): void {
+        it('returns null', function (): void {
+            expect(new SingleChoiceSettings()->initialValue())->toBeNull();
+        });
+    });
+
+    describe('messages()', function (): void {
+        it('returns array with required message key', function (): void {
+            $messages = new SingleChoiceSettings()->messages('language');
+
+            expect($messages)->toHaveKey('language.required');
+        });
+
+        it('uses the provided attribute name in the key', function (): void {
+            $messages = new SingleChoiceSettings()->messages('preferred_stack');
+
+            expect($messages)->toHaveKey('preferred_stack.required');
+        });
+    });
+});

--- a/app-modules/screening/tests/Unit/Settings/TextSettingsTest.php
+++ b/app-modules/screening/tests/Unit/Settings/TextSettingsTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Screening\QuestionTypes\Settings\TextSettings;
+
+describe('TextSettings', function (): void {
+    describe('fromArray()', function (): void {
+        it('creates with default values when array is empty', function (): void {
+            $settings = TextSettings::fromArray([]);
+
+            expect($settings->maxLength)->toBeNull()
+                ->and($settings->multiline)->toBeFalse()
+                ->and($settings->placeholder)->toBeNull();
+        });
+
+        it('casts max_length to int', function (): void {
+            $settings = TextSettings::fromArray(['max_length' => '500']);
+
+            expect($settings->maxLength)->toBe(500);
+        });
+
+        it('reads multiline as boolean', function (): void {
+            $settings = TextSettings::fromArray(['multiline' => true]);
+
+            expect($settings->multiline)->toBeTrue();
+        });
+
+        it('reads placeholder as string', function (): void {
+            $settings = TextSettings::fromArray(['placeholder' => 'Digite aqui...']);
+
+            expect($settings->placeholder)->toBe('Digite aqui...');
+        });
+
+        it('creates from array with all fields populated', function (): void {
+            $settings = TextSettings::fromArray([
+                'max_length' => '250',
+                'multiline' => true,
+                'placeholder' => 'Descreva sua experiência',
+            ]);
+
+            expect($settings->maxLength)->toBe(250)
+                ->and($settings->multiline)->toBeTrue()
+                ->and($settings->placeholder)->toBe('Descreva sua experiência');
+        });
+    });
+
+    describe('toArray()', function (): void {
+        it('serializes all properties to array', function (): void {
+            $settings = new TextSettings(maxLength: 300, multiline: true, placeholder: 'Ex:');
+
+            expect($settings->toArray())->toBe([
+                'max_length' => 300,
+                'multiline' => true,
+                'placeholder' => 'Ex:',
+            ]);
+        });
+
+        it('serializes null values correctly', function (): void {
+            $settings = new TextSettings();
+
+            expect($settings->toArray())->toBe([
+                'max_length' => null,
+                'multiline' => false,
+                'placeholder' => null,
+            ]);
+        });
+    });
+
+    describe('rules()', function (): void {
+        it('includes required rule when required is true', function (): void {
+            $settings = new TextSettings();
+
+            expect($settings->rules('answer', true))->toContain('required');
+        });
+
+        it('does not include required rule when required is false', function (): void {
+            $settings = new TextSettings();
+
+            expect($settings->rules('answer', false))->not->toContain('required');
+        });
+
+        it('includes max rule when maxLength is set (note: space after colon)', function (): void {
+            $settings = new TextSettings(maxLength: 200);
+
+            expect($settings->rules('answer', false))->toContain('max: 200');
+        });
+
+        it('does not include max rule when maxLength is null', function (): void {
+            $settings = new TextSettings();
+            $rules = $settings->rules('answer', false);
+
+            $hasMaxRule = collect($rules)->contains(fn ($r) => str_starts_with((string) $r, 'max:'));
+
+            expect($hasMaxRule)->toBeFalse();
+        });
+
+        it('combines required and max rules', function (): void {
+            $settings = new TextSettings(maxLength: 100);
+            $rules = $settings->rules('answer', true);
+
+            expect($rules)->toContain('required')
+                ->and($rules)->toContain('max: 100');
+        });
+    });
+
+    describe('initialValue()', function (): void {
+        it('returns null', function (): void {
+            expect(new TextSettings()->initialValue())->toBeNull();
+        });
+    });
+
+    describe('messages()', function (): void {
+        it('returns array with required and max message keys', function (): void {
+            $messages = new TextSettings()->messages('answer');
+
+            expect($messages)->toHaveKey('answer.required')
+                ->and($messages)->toHaveKey('answer.max');
+        });
+
+        it('uses the provided attribute name in all keys', function (): void {
+            $messages = new TextSettings()->messages('bio');
+
+            expect($messages)->toHaveKey('bio.required')
+                ->and($messages)->toHaveKey('bio.max');
+        });
+    });
+});

--- a/app-modules/screening/tests/Unit/Settings/YesNoSettingsTest.php
+++ b/app-modules/screening/tests/Unit/Settings/YesNoSettingsTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Screening\QuestionTypes\Settings\YesNoSettings;
+
+describe('YesNoSettings', function (): void {
+    describe('fromArray()', function (): void {
+        it('creates an instance regardless of input data', function (): void {
+            expect(YesNoSettings::fromArray([]))->toBeInstanceOf(YesNoSettings::class);
+            expect(YesNoSettings::fromArray(['irrelevant' => 'data']))->toBeInstanceOf(YesNoSettings::class);
+        });
+    });
+
+    describe('toArray()', function (): void {
+        it('returns an empty array (yes/no has no extra settings)', function (): void {
+            expect(new YesNoSettings()->toArray())->toBe([]);
+        });
+    });
+
+    describe('rules()', function (): void {
+        it('includes required rule when required is true', function (): void {
+            $settings = new YesNoSettings();
+
+            expect($settings->rules('answer', true))->toContain('required');
+        });
+
+        it('returns empty rules when required is false', function (): void {
+            $settings = new YesNoSettings();
+
+            expect($settings->rules('answer', false))->toBe([]);
+        });
+    });
+
+    describe('initialValue()', function (): void {
+        it('returns null', function (): void {
+            expect(new YesNoSettings()->initialValue())->toBeNull();
+        });
+    });
+
+    describe('messages()', function (): void {
+        it('returns array with required message key', function (): void {
+            $messages = new YesNoSettings()->messages('answer');
+
+            expect($messages)->toHaveKey('answer.required');
+        });
+
+        it('uses the provided attribute name in the key', function (): void {
+            $messages = new YesNoSettings()->messages('custom_field');
+
+            expect($messages)->toHaveKey('custom_field.required');
+        });
+    });
+});


### PR DESCRIPTION
This pull request adds comprehensive unit tests for the screening module, focusing on the core DTOs, collections, and question type classes. The tests cover construction, data normalization, serialization, and registry behaviors, ensuring correct handling of various question types and response data.

**Unit tests for DTOs and collections:**
- Added tests for `ScreeningResponseDTO` covering the `make()` factory, normalization of `response_value`, and direct construction.
- Added tests for `ScreeningResponseCollection` including construction, addition, array conversion, iteration, and JSON serialization/round-trip behaviors.

**Unit tests for question types:**
- Added tests for `YesNoType`, `TextType`, `NumberType`, `SingleChoiceType`, and `MultipleChoiceType`, verifying their enum mapping, settings class, default settings, component path, schema, label, and icon. [[1]](diffhunk://#diff-b568df220fa6e5f141ee8205e671fccc7ea6b4579046a56124c168c7ccfe1abcR1-R37) [[2]](diffhunk://#diff-06ba8ad2bd2dd9c939874d0f905a2ce38955c6864df7ddcfa24a78a27c2760a6R1-R37) [[3]](diffhunk://#diff-e3878483e59622fd71118e849963c5a9c2646e83d0e2ae1cf072c1448b8f967eR1-R37) [[4]](diffhunk://#diff-9ea9b34295ef59461b6728a192e83f9c621d2ff5f0d130738801aad7bea4604fR1-R37) [[5]](diffhunk://#diff-6612585cc75b5548214f858825cf0a1f0429a65b51a094c5f49c1abeb8a94a97R1-R37)

**Unit tests for the question type registry:**
- Added tests for `QuestionTypeRegistry` to verify correct class retrieval, listing all types, and fetching settings schemas for each type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for the screening module: response DTOs and collections (construction, iteration, JSON serialization, value normalization), all question types (Yes/No, Text, Number, Single/Multiple Choice) and their metadata, settings classes (validation rules, defaults, serialization, initial values/messages), and the question-type registry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->