### PR TITLE
fix: job requisition form

### DIFF
--- a/app-modules/panel-organization/src/Filament/Resources/Recruitment/JobRequisitions/Schemas/JobRequisitionForm.php
+++ b/app-modules/panel-organization/src/Filament/Resources/Recruitment/JobRequisitions/Schemas/JobRequisitionForm.php
@@ -57,7 +57,11 @@ class JobRequisitionForm
                                             ->label(__('recruitment::filament.requisition.job_posting.fields.title'))
                                             ->required()
                                             ->live(debounce: 700)
-                                            ->afterStateUpdated(function (Set $set, string $state): void {
+                                            ->afterStateUpdated(function (Set $set, ?string $state): void {
+                                                if (blank($state)) {
+                                                    return;
+                                                }
+
                                                 $slug = sprintf('%s-%s', $state, Str::random(4));
                                                 $set('slug', str($slug)->slug());
                                             })


### PR DESCRIPTION
This pull request makes a small but important improvement to the `JobRequisitionForm` schema by adding a check to ensure that the job title is not blank before generating and setting a slug. This prevents unnecessary or invalid slug creation when the title field is empty.

* Validation improvement:
  * Updated the `afterStateUpdated` callback for the job posting title field in `JobRequisitionForm.php` to check if the state is blank before generating a slug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved slug field handling in job requisition forms. The slug field will no longer be automatically updated when the job title field is empty or blank, preventing the creation of invalid slug values. This ensures better data integrity when creating or editing job requisition entries with incomplete information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->