### PR TITLE
fix: stuff

### DIFF
--- a/app-modules/panel-app/src/Livewire/JobRecommendations.php
+++ b/app-modules/panel-app/src/Livewire/JobRecommendations.php
@@ -43,7 +43,7 @@ class JobRecommendations extends Component
             ->withCount('applications')
             ->where('status', RequisitionStatusEnum::Published->value)
             ->when($this->search, fn ($q) => $q->whereHas('post', fn (Builder $p) => $p->where('title', 'like', sprintf('%%%s%%', $this->search))))
-            ->unless($this->jobTypes === [], fn ($q) => $q->whereIn('employment_type', $this->jobTypes))
+            ->unless($this->jobTypes === [], fn ($q) => $q->whereIn('employment_type', $this->normalizedJobTypes()))
             ->latest()
             ->paginate(12);
     }
@@ -51,5 +51,23 @@ class JobRecommendations extends Component
     public function render(): View
     {
         return view('panel-app::livewire.job-recommendations');
+    }
+
+    /**
+     * Normaliza $jobTypes para strings, independente de como o Livewire serializou
+     * (string vinda da URL, EmploymentTypeEnum, ou array do EnumSynth).
+     *
+     * @return array<int, string>
+     */
+    private function normalizedJobTypes(): array
+    {
+        return array_map(
+            fn (mixed $type): string => match (true) {
+                $type instanceof EmploymentTypeEnum => $type->value,
+                is_array($type) => (string) $type['value'],
+                default => (string) $type,
+            },
+            $this->jobTypes
+        );
     }
 }

--- a/app-modules/panel-app/src/Livewire/JobRecommendations.php
+++ b/app-modules/panel-app/src/Livewire/JobRecommendations.php
@@ -26,7 +26,7 @@ class JobRecommendations extends Component
     public string $workModel = '';
 
     /**
-     * @var array<int, EmploymentTypeEnum>
+     * @var array<int, EmploymentTypeEnum|array{value: string, class: string}|string>
      */
     #[Url]
     public array $jobTypes = [];
@@ -64,8 +64,8 @@ class JobRecommendations extends Component
         return array_map(
             fn (mixed $type): string => match (true) {
                 $type instanceof EmploymentTypeEnum => $type->value,
-                is_array($type) => (string) $type['value'],
-                default => (string) $type,
+                is_array($type) => $type['value'],
+                default => $type,
             },
             $this->jobTypes
         );

--- a/app-modules/panel-app/src/Livewire/JobRecommendations.php
+++ b/app-modules/panel-app/src/Livewire/JobRecommendations.php
@@ -26,7 +26,7 @@ class JobRecommendations extends Component
     public string $workModel = '';
 
     /**
-     * @var array<int, EmploymentTypeEnum|array{value: string, class: string}|string>
+     * @var array<int, EmploymentTypeEnum|array<string, mixed>|string>
      */
     #[Url]
     public array $jobTypes = [];
@@ -61,13 +61,17 @@ class JobRecommendations extends Component
      */
     private function normalizedJobTypes(): array
     {
-        return array_map(
-            fn (mixed $type): string => match (true) {
-                $type instanceof EmploymentTypeEnum => $type->value,
-                is_array($type) => $type['value'],
-                default => $type,
-            },
-            $this->jobTypes
-        );
+        return array_values(array_filter(
+            array_map(
+                fn (mixed $type): ?string => match (true) {
+                    $type instanceof EmploymentTypeEnum => $type->value,
+                    is_array($type) && isset($type['value']) && is_string($type['value']) => $type['value'],
+                    is_string($type) => $type,
+                    default => null,
+                },
+                $this->jobTypes
+            ),
+            static fn (?string $type): bool => $type !== null
+        ));
     }
 }

--- a/app-modules/panel-app/tests/Feature/Livewire/JobRecommendationsTest.php
+++ b/app-modules/panel-app/tests/Feature/Livewire/JobRecommendationsTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\App\Livewire\JobRecommendations;
+use He4rt\Recruitment\Requisitions\Enums\EmploymentTypeEnum;
+use He4rt\Recruitment\Requisitions\Enums\RequisitionStatusEnum;
+use He4rt\Recruitment\Requisitions\Models\JobRequisition;
+
+use function Pest\Livewire\livewire;
+
+it('renders all published public jobs when no filter is applied', function (): void {
+    $jobs = JobRequisition::factory(3)->available()->create();
+
+    $draft = JobRequisition::factory()->create(['status' => RequisitionStatusEnum::Draft]);
+
+    $livewire = livewire(JobRecommendations::class)->assertOk();
+
+    $jobs->each(fn (JobRequisition $job) => $livewire->assertSee($job->getKey()));
+
+    $livewire->assertDontSee($draft->getKey());
+});
+
+it('filters jobs by employment type when jobTypes is an array of strings', function (): void {
+    $fullTime = JobRequisition::factory()->available()->create([
+        'employment_type' => EmploymentTypeEnum::FullTimeEmployee,
+    ]);
+
+    $partTime = JobRequisition::factory()->available()->create([
+        'employment_type' => EmploymentTypeEnum::PartTime,
+    ]);
+
+    livewire(JobRecommendations::class)
+        ->set('jobTypes', [EmploymentTypeEnum::FullTimeEmployee->value])
+        ->assertOk()
+        ->assertSee($fullTime->getKey())
+        ->assertDontSee($partTime->getKey());
+});
+
+it('filters jobs when jobTypes contains EnumSynth nested array format', function (): void {
+    $fullTime = JobRequisition::factory()->available()->create([
+        'employment_type' => EmploymentTypeEnum::FullTimeEmployee,
+    ]);
+
+    $partTime = JobRequisition::factory()->available()->create([
+        'employment_type' => EmploymentTypeEnum::PartTime,
+    ]);
+
+    // Simula o formato que o EnumSynth do Livewire produz ao desserializar o snapshot
+    livewire(JobRecommendations::class)
+        ->set('jobTypes', [
+            ['value' => EmploymentTypeEnum::FullTimeEmployee->value, 'class' => EmploymentTypeEnum::class],
+        ])
+        ->assertOk()
+        ->assertSee($fullTime->getKey())
+        ->assertDontSee($partTime->getKey());
+});
+
+it('returns no jobs when jobTypes filter matches no employment type in the database', function (): void {
+    JobRequisition::factory()->available()->create([
+        'employment_type' => EmploymentTypeEnum::FullTimeEmployee,
+    ]);
+
+    livewire(JobRecommendations::class)
+        ->set('jobTypes', ['non_existent_type'])
+        ->assertOk()
+        ->assertSee('0');
+});

--- a/app-modules/panel-app/tests/Feature/Livewire/JobRecommendationsTest.php
+++ b/app-modules/panel-app/tests/Feature/Livewire/JobRecommendationsTest.php
@@ -57,12 +57,12 @@ it('filters jobs when jobTypes contains EnumSynth nested array format', function
 });
 
 it('returns no jobs when jobTypes filter matches no employment type in the database', function (): void {
-    JobRequisition::factory()->available()->create([
+    $job = JobRequisition::factory()->available()->create([
         'employment_type' => EmploymentTypeEnum::FullTimeEmployee,
     ]);
 
     livewire(JobRecommendations::class)
         ->set('jobTypes', ['non_existent_type'])
         ->assertOk()
-        ->assertSee('0');
+        ->assertDontSee((string) $job->getKey());
 });


### PR DESCRIPTION
## Problema

O componente `JobRecommendations` estava lançando `InvalidArgumentException: Nested arrays may not be passed to whereIn method` em Staging.[

- [Nightwatch issue](https://nightwatch.laravel.com/us/environments/a10a1840-0043-4031-a704-af1e6470926b/issues/9)

A propriedade `$jobTypes` usa `#[Url]` e é declarada como `array<int, EmploymentTypeEnum>`. Quando o Livewire serializa instâncias de enum no snapshot do componente, o `EnumSynth` converte cada enum para um array aninhado no formato:

```json
{"class": "He4rt\\Recruitment\\Requisitions\\Enums\\EmploymentTypeEnum", "value": "full_time_employee"}
```

Na requisição seguinte (`/livewire/update`), esse array aninhado é reidratado diretamente em `$jobTypes`. O `whereIn` do Laravel não aceita nested arrays, lançando a exception.

## Causa raiz

```
[Dehydrate] EmploymentTypeEnum → ['value' => 'full_time_employee', 'class' => '...']
[Hydrate]   $jobTypes = [['value' => ...], ['value' => ...]]
[Query]     ->whereIn('employment_type', $jobTypes) → InvalidArgumentException ✗
```

## Solução

Adicionado o método `normalizedJobTypes()` que normaliza defensivamente os elementos de `$jobTypes` para strings antes de passar ao `whereIn`, tratando os três formatos possíveis que o Livewire pode entregar na boundary do componente:

- `EmploymentTypeEnum` → extrai `->value`
- `array` (formato EnumSynth) → extrai `$type['value']`
- `string` (vinda direto da URL) → passa como está

O docblock de `$jobTypes` foi atualizado para refletir a union type real, resolvendo os erros do PHPStan.

## Arquivos alterados

- `app-modules/panel-app/src/Livewire/JobRecommendations.php`
- `app-modules/panel-app/tests/Feature/Livewire/JobRecommendationsTest.php` *(novo)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Job recommendations filtering now correctly handles mixed input formats for employment-type filters, showing published jobs and excluding drafts as expected

* **Tests**
  * Added integration tests covering multiple jobTypes input shapes and filtering outcomes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->