### PR TITLE
feat: rpq epico 11

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,7 +70,8 @@ AWS_BUCKET=
 AWS_USE_PATH_STYLE_ENDPOINT=false
 
 GEMINI_API_KEY=
-AI_FALLBACK_MODEL=gemini-3.1-flash-lite-preview
+AI_MODEL=gemini-3.1-flash-lite-preview
+AI_FALLBACK_MODEL=gemini-3-flash-preview
 
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=

--- a/Makefile
+++ b/Makefile
@@ -71,65 +71,7 @@ test-feature: ## Run feature tests
 
 .PHONY: setup-test-db
 setup-test-db: ## Create the testing database for running tests
-	@PGHOST=localhost PGUSER=postgres PGPASSWORD=postgres createdb test_sycorax 2>/dev/null || echo "Database test_sycorax already exists"
-
-## Module Tests
-
-.PHONY: test-module-applications
-test-module-applications: ## Run applications module tests
-	@$(CURDIR)/vendor/bin/pest --parallel --compact app-modules/applications/tests/
-
-.PHONY: test-module-candidates
-test-module-candidates: ## Run candidates module tests
-	@$(CURDIR)/vendor/bin/pest --parallel --compact app-modules/candidates/tests/
-
-.PHONY: test-module-feedback
-test-module-feedback: ## Run feedback module tests
-	@$(CURDIR)/vendor/bin/pest --parallel --compact app-modules/feedback/tests/
-
-.PHONY: test-module-links
-test-module-links: ## Run links module tests
-	@$(CURDIR)/vendor/bin/pest --parallel --compact app-modules/links/tests/
-
-.PHONY: test-module-location
-test-module-location: ## Run location module tests
-	@$(CURDIR)/vendor/bin/pest --parallel --compact app-modules/location/tests/
-
-.PHONY: test-module-panel-admin
-test-module-panel-admin: ## Run panel-admin module tests
-	@$(CURDIR)/vendor/bin/pest --parallel --compact app-modules/panel-admin/tests/
-
-.PHONY: test-module-panel-app
-test-module-panel-app: ## Run panel-app module tests
-	@$(CURDIR)/vendor/bin/pest --parallel --compact app-modules/panel-app/tests/
-
-.PHONY: test-module-panel-organization
-test-module-panel-organization: ## Run panel-organization module tests
-	@$(CURDIR)/vendor/bin/pest --parallel --compact app-modules/panel-organization/tests/
-
-.PHONY: test-module-permissions
-test-module-permissions: ## Run permissions module tests
-	@$(CURDIR)/vendor/bin/pest --parallel --compact app-modules/permissions/tests/
-
-.PHONY: test-module-recruitment
-test-module-recruitment: ## Run recruitment module tests
-	@$(CURDIR)/vendor/bin/pest --parallel --compact app-modules/recruitment/tests/
-
-.PHONY: test-module-screening
-test-module-screening: ## Run screening module tests
-	@$(CURDIR)/vendor/bin/pest --parallel --compact app-modules/screening/tests/
-
-.PHONY: test-module-teams
-test-module-teams: ## Run teams module tests
-	@$(CURDIR)/vendor/bin/pest --parallel --compact app-modules/teams/tests/
-
-.PHONY: test-module-term
-test-module-term: ## Run term module tests
-	@$(CURDIR)/vendor/bin/pest --parallel --compact app-modules/term/tests/
-
-.PHONY: test-module-users
-test-module-users: ## Run users module tests
-	@$(CURDIR)/vendor/bin/pest --parallel --compact app-modules/users/tests/
+	@docker compose exec sycorax-db psql -U postgres -c "CREATE DATABASE test_recruit_party_quest;" 2>/dev/null || echo "Database test_recruit_party_quest already exists"
 
 .PHONY: migrate-fresh
 migrate-fresh: ## Run migrations and seed the database

--- a/app-modules/ai/config/ai.php
+++ b/app-modules/ai/config/ai.php
@@ -95,8 +95,8 @@ return [
     'provider' => [
         'gemini' => [
             'enum' => env('AI_PROVIDER', Provider::Gemini->name),
-            'model' => env('AI_MODEL', 'gemini-2.5-flash'),
-            'fallback_model' => env('AI_FALLBACK_MODEL', 'gemini-3.1-flash-lite-preview'),
+            'model' => env('AI_MODEL', 'gemini-3.1-flash-lite-preview'),
+            'fallback_model' => env('AI_FALLBACK_MODEL', 'gemini-3-flash-preview'),
         ],
     ],
 ];

--- a/app-modules/candidates/src/Actions/Onboarding/CompleteOnboardingAction.php
+++ b/app-modules/candidates/src/Actions/Onboarding/CompleteOnboardingAction.php
@@ -119,6 +119,7 @@ final readonly class CompleteOnboardingAction implements AiAutocompleteInterface
         /** @var Response $response */
         $response = Prism::structured()
             ->using($provider, $model)
+            ->withClientOptions(['timeout' => 90, 'connect_timeout' => 10])
             ->withSchema(CvDataSchema::make($this->notAnCv))
             ->withPrompt(
                 CvAnalysisPrompt::make($this->notAnCv),

--- a/app-modules/candidates/src/Actions/Onboarding/CompleteOnboardingAction.php
+++ b/app-modules/candidates/src/Actions/Onboarding/CompleteOnboardingAction.php
@@ -16,7 +16,9 @@ use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Support\Facades\Cache;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Exceptions\PrismProviderOverloadedException;
 use Prism\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\Exceptions\PrismRequestTooLargeException;
 use Prism\Prism\Facades\Prism;
 use Prism\Prism\Structured\Response;
 use Prism\Prism\ValueObjects\Media\Document;
@@ -89,14 +91,23 @@ final readonly class CompleteOnboardingAction implements AiAutocompleteInterface
                 $lastException = $e;
 
                 continue;
-            } catch (PrismException $e) {
-                logger()->error('Prism error, opening circuit breaker', [
+            } catch (PrismProviderOverloadedException|PrismRequestTooLargeException $e) {
+                logger()->warning('Prism transient error, opening circuit breaker', [
                     'model' => $model,
                     'circuit_key' => $circuitKey,
                     'error' => $e->getMessage(),
                     'exception' => $e::class,
                 ]);
                 Cache::put($circuitKey, true, now()->addMinutes(3));
+                $lastException = $e;
+
+                continue;
+            } catch (PrismException $e) {
+                logger()->error('Prism permanent error, not opening circuit breaker', [
+                    'model' => $model,
+                    'error' => $e->getMessage(),
+                    'exception' => $e::class,
+                ]);
                 $lastException = $e;
 
                 continue;
@@ -119,7 +130,7 @@ final readonly class CompleteOnboardingAction implements AiAutocompleteInterface
         /** @var Response $response */
         $response = Prism::structured()
             ->using($provider, $model)
-            ->withClientOptions(['timeout' => 90, 'connect_timeout' => 10])
+            ->withClientOptions(['timeout' => 70, 'connect_timeout' => 10])
             ->withSchema(CvDataSchema::make($this->notAnCv))
             ->withPrompt(
                 CvAnalysisPrompt::make($this->notAnCv),

--- a/app-modules/candidates/src/Actions/Onboarding/CompleteOnboardingAction.php
+++ b/app-modules/candidates/src/Actions/Onboarding/CompleteOnboardingAction.php
@@ -91,7 +91,7 @@ final readonly class CompleteOnboardingAction implements AiAutocompleteInterface
                 $lastException = $e;
 
                 continue;
-            } catch (PrismProviderOverloadedException|PrismRequestTooLargeException $e) {
+            } catch (PrismProviderOverloadedException $e) {
                 logger()->warning('Prism transient error, opening circuit breaker', [
                     'model' => $model,
                     'circuit_key' => $circuitKey,
@@ -99,6 +99,15 @@ final readonly class CompleteOnboardingAction implements AiAutocompleteInterface
                     'exception' => $e::class,
                 ]);
                 Cache::put($circuitKey, true, now()->addMinutes(3));
+                $lastException = $e;
+
+                continue;
+            } catch (PrismRequestTooLargeException $e) {
+                logger()->warning('Prism request too large, skipping model without opening circuit breaker', [
+                    'model' => $model,
+                    'error' => $e->getMessage(),
+                    'exception' => $e::class,
+                ]);
                 $lastException = $e;
 
                 continue;

--- a/app-modules/candidates/src/Actions/Onboarding/CompleteOnboardingAction.php
+++ b/app-modules/candidates/src/Actions/Onboarding/CompleteOnboardingAction.php
@@ -13,6 +13,7 @@ use He4rt\Candidates\DTOs\CandidateWorkExperienceDTO;
 use He4rt\Candidates\Enums\ResumeErrorReasons;
 use He4rt\Candidates\Exceptions\OnboardingException;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
+use Illuminate\Support\Facades\Cache;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Exceptions\PrismRateLimitedException;
@@ -64,22 +65,41 @@ final readonly class CompleteOnboardingAction implements AiAutocompleteInterface
         $lastException = null;
 
         foreach ($models as $model) {
+            $circuitKey = 'cb:gemini:'.$model;
+
+            if (Cache::has($circuitKey)) {
+                logger()->info('Circuit breaker active, skipping model', [
+                    'model' => $model,
+                    'circuit_key' => $circuitKey,
+                ]);
+
+                continue;
+            }
+
             try {
                 return $this->callPrism($file, $provider, $model);
             } catch (PrismRateLimitedException $e) {
-                logger()->warning('Gemini rate limit hit, trying next model', [
+                logger()->warning('Gemini rate limit hit, opening circuit breaker', [
                     'model' => $model,
                     'retry_after' => $e->retryAfter,
+                    'circuit_key' => $circuitKey,
+                    'error' => $e->getMessage(),
                 ]);
+                Cache::put($circuitKey, true, now()->addMinutes(3));
                 $lastException = $e;
 
                 continue;
             } catch (PrismException $e) {
-                logger()->error('Prism non-recoverable error during CV analysis', [
+                logger()->error('Prism error, opening circuit breaker', [
                     'model' => $model,
+                    'circuit_key' => $circuitKey,
                     'error' => $e->getMessage(),
+                    'exception' => $e::class,
                 ]);
-                throw OnboardingException::rateLimiting(previous: $e);
+                Cache::put($circuitKey, true, now()->addMinutes(3));
+                $lastException = $e;
+
+                continue;
             }
         }
 

--- a/app-modules/candidates/src/CandidatesServiceProvider.php
+++ b/app-modules/candidates/src/CandidatesServiceProvider.php
@@ -9,7 +9,9 @@ use He4rt\Candidates\Models\Candidate;
 use He4rt\Candidates\Models\Education;
 use He4rt\Candidates\Models\Skill;
 use He4rt\Candidates\Models\WorkExperience;
+use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\ServiceProvider;
 
 class CandidatesServiceProvider extends ServiceProvider
@@ -20,6 +22,8 @@ class CandidatesServiceProvider extends ServiceProvider
     {
         $this->loadTranslationsFrom(__DIR__.'/../lang', 'candidates');
         $this->loadRoutesFrom(__DIR__.'/../routes/channels.php');
+
+        RateLimiter::for('gemini-cv-analysis', fn () => new Limit(maxAttempts: 3, decaySeconds: 10));
 
         Relation::morphMap([
             'candidates' => Candidate::class,

--- a/app-modules/candidates/src/Jobs/AiAnalyzeResumeJob.php
+++ b/app-modules/candidates/src/Jobs/AiAnalyzeResumeJob.php
@@ -14,7 +14,10 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Redis;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
+use Symfony\Component\HttpFoundation\Response;
+use Throwable;
 
 final class AiAnalyzeResumeJob implements ShouldQueue
 {
@@ -23,14 +26,64 @@ final class AiAnalyzeResumeJob implements ShouldQueue
     use Queueable;
     use SerializesModels;
 
+    public int $timeout = 90;
+
     public function __construct(
         public string $temporaryFile,
         public string $userId
     ) {}
 
+    public function tries(): int
+    {
+        return 2;
+    }
+
+    /** @return array<int, int> */
+    public function backoff(): array
+    {
+        return [15];
+    }
+
     public function handle(): void
     {
+        Redis::throttle('gemini-cv-analysis')
+            ->allow(3)
+            ->every(10)
+            ->then(
+                function (): void {
+                    $this->processAnalysis();
+                },
+                function (): void {
+                    logger()->info('Gemini CV analysis throttled, releasing job', [
+                        'userId' => $this->userId,
+                        'attempt' => $this->attempts(),
+                    ]);
+                    $this->release(5);
+                }
+            );
+    }
 
+    public function failed(?Throwable $exception): void
+    {
+        logger()->error('CV analysis permanently failed after all retries', [
+            'userId' => $this->userId,
+            'exception' => $exception?->getMessage(),
+            'class' => $exception instanceof Throwable ? $exception::class : null,
+        ]);
+
+        broadcast(new AnalyzeResumeEvent(
+            status: ResumeAnalyzeStatus::Error,
+            fields: null,
+            userId: $this->userId,
+            message: __('panel-app::pages/onboarding.notifications.rate_limit.body'),
+            code: Response::HTTP_SERVICE_UNAVAILABLE,
+        ));
+
+        report_if($exception instanceof Throwable, $exception);
+    }
+
+    private function processAnalysis(): void
+    {
         $temporaryFile = TemporaryUploadedFile::createFromLivewire($this->temporaryFile);
 
         try {
@@ -38,14 +91,31 @@ final class AiAnalyzeResumeJob implements ShouldQueue
             $fields = resolve(AiAutocompleteInterface::class)->execute($temporaryFile);
             broadcast(new AnalyzeResumeEvent(ResumeAnalyzeStatus::Finished, $fields, $this->userId));
         } catch (OnboardingException $onboardingException) {
-            broadcast(new AnalyzeResumeEvent(
-                status: ResumeAnalyzeStatus::Error,
-                fields: null,
-                userId: $this->userId,
-                message: $onboardingException->getMessage(),
-                code: $onboardingException->getCode(),
-            ));
-        }
+            if ($onboardingException->getCode() === Response::HTTP_UNPROCESSABLE_ENTITY) {
+                logger()->warning('CV rejected as invalid document', [
+                    'userId' => $this->userId,
+                    'message' => $onboardingException->getMessage(),
+                ]);
 
+                broadcast(new AnalyzeResumeEvent(
+                    status: ResumeAnalyzeStatus::Error,
+                    fields: null,
+                    userId: $this->userId,
+                    message: $onboardingException->getMessage(),
+                    code: $onboardingException->getCode(),
+                ));
+
+                return;
+            }
+
+            logger()->warning('Transient CV analysis failure, will retry', [
+                'userId' => $this->userId,
+                'attempt' => $this->attempts(),
+                'error' => $onboardingException->getMessage(),
+                'code' => $onboardingException->getCode(),
+            ]);
+
+            throw $onboardingException;
+        }
     }
 }

--- a/app-modules/candidates/src/Jobs/AiAnalyzeResumeJob.php
+++ b/app-modules/candidates/src/Jobs/AiAnalyzeResumeJob.php
@@ -13,8 +13,8 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\Middleware\RateLimited;
 use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\Redis;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Symfony\Component\HttpFoundation\Response;
 use Throwable;
@@ -44,23 +44,15 @@ final class AiAnalyzeResumeJob implements ShouldQueue
         return [15];
     }
 
+    /** @return array<int, object> */
+    public function middleware(): array
+    {
+        return [new RateLimited('gemini-cv-analysis')];
+    }
+
     public function handle(): void
     {
-        Redis::throttle('gemini-cv-analysis')
-            ->allow(3)
-            ->every(10)
-            ->then(
-                function (): void {
-                    $this->processAnalysis();
-                },
-                function (): void {
-                    logger()->info('Gemini CV analysis throttled, releasing job', [
-                        'userId' => $this->userId,
-                        'attempt' => $this->attempts(),
-                    ]);
-                    $this->release(5);
-                }
-            );
+        $this->processAnalysis();
     }
 
     public function failed(?Throwable $exception): void

--- a/app-modules/candidates/tests/Feature/AiAnalyzeResumeJobTest.php
+++ b/app-modules/candidates/tests/Feature/AiAnalyzeResumeJobTest.php
@@ -10,8 +10,10 @@ use He4rt\Candidates\Exceptions\OnboardingException;
 use He4rt\Candidates\Jobs\AiAnalyzeResumeJob;
 use He4rt\Users\User;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Redis;
 use Illuminate\Support\Facades\Storage;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
+use Symfony\Component\HttpFoundation\Response;
 
 beforeEach(function (): void {
     $this->user = User::factory()->create();
@@ -22,6 +24,15 @@ beforeEach(function (): void {
     Storage::disk('tmp-for-tests')->put('curriculum.pdf', 'fake pdf content');
 
     $this->temporaryFilename = 'curriculum.pdf';
+
+    // Mock Redis throttle to pass through immediately to the success callback
+    $throttle = Mockery::mock();
+    $throttle->shouldReceive('allow')->andReturnSelf();
+    $throttle->shouldReceive('every')->andReturnSelf();
+    $throttle->shouldReceive('then')->andReturnUsing(
+        fn (callable $success, callable $failure) => $success()
+    );
+    Redis::shouldReceive('throttle')->andReturn($throttle);
 });
 
 it('broadcasts a Finished event when the CV analysis succeeds', function (): void {
@@ -39,20 +50,12 @@ it('broadcasts a Finished event when the CV analysis succeeds', function (): voi
         && $event->userId === (string) $this->user->id);
 });
 
-it('broadcasts an Error event when the CV analysis throws OnboardingException', function (): void {
-    $errorMessage = 'Something went wrong';
-    $errorCode = 503;
-
-    app()->bind(AiAutocompleteInterface::class, fn () => new readonly class($errorMessage, $errorCode) implements AiAutocompleteInterface
+it('broadcasts an Error event immediately for an invalid CV without retrying', function (): void {
+    app()->bind(AiAutocompleteInterface::class, fn () => new readonly class implements AiAutocompleteInterface
     {
-        public function __construct(
-            private string $message,
-            private int $code,
-        ) {}
-
         public function execute(TemporaryUploadedFile $file): CandidateOnboardingDTO
         {
-            throw new OnboardingException($this->message, $this->code);
+            throw new OnboardingException('File sent is not a curriculum.', Response::HTTP_UNPROCESSABLE_ENTITY);
         }
     });
 
@@ -60,6 +63,30 @@ it('broadcasts an Error event when the CV analysis throws OnboardingException', 
 
     Event::assertDispatched(fn (AnalyzeResumeEvent $event) => $event->status === ResumeAnalyzeStatus::Error
         && $event->userId === (string) $this->user->id
-        && $event->message === $errorMessage
-        && $event->code === $errorCode);
+        && $event->code === Response::HTTP_UNPROCESSABLE_ENTITY);
+});
+
+it('re-throws transient OnboardingException for queue retry', function (): void {
+    app()->bind(AiAutocompleteInterface::class, fn () => new readonly class implements AiAutocompleteInterface
+    {
+        public function execute(TemporaryUploadedFile $file): CandidateOnboardingDTO
+        {
+            throw new OnboardingException('Service unavailable.', Response::HTTP_SERVICE_UNAVAILABLE);
+        }
+    });
+
+    expect(fn () => new AiAnalyzeResumeJob($this->temporaryFilename, $this->user->id)->handle())
+        ->toThrow(OnboardingException::class);
+
+    Event::assertNotDispatched(AnalyzeResumeEvent::class);
+});
+
+it('broadcasts an Error event when failed() is called after all retries are exhausted', function (): void {
+    $exception = new RuntimeException('All retries exhausted.');
+
+    new AiAnalyzeResumeJob($this->temporaryFilename, $this->user->id)->failed($exception);
+
+    Event::assertDispatched(fn (AnalyzeResumeEvent $event) => $event->status === ResumeAnalyzeStatus::Error
+        && $event->userId === (string) $this->user->id
+        && $event->code === Response::HTTP_SERVICE_UNAVAILABLE);
 });

--- a/app-modules/candidates/tests/Feature/AiAnalyzeResumeJobTest.php
+++ b/app-modules/candidates/tests/Feature/AiAnalyzeResumeJobTest.php
@@ -10,7 +10,6 @@ use He4rt\Candidates\Exceptions\OnboardingException;
 use He4rt\Candidates\Jobs\AiAnalyzeResumeJob;
 use He4rt\Users\User;
 use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Facades\Redis;
 use Illuminate\Support\Facades\Storage;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Symfony\Component\HttpFoundation\Response;
@@ -24,15 +23,6 @@ beforeEach(function (): void {
     Storage::disk('tmp-for-tests')->put('curriculum.pdf', 'fake pdf content');
 
     $this->temporaryFilename = 'curriculum.pdf';
-
-    // Mock Redis throttle to pass through immediately to the success callback
-    $throttle = Mockery::mock();
-    $throttle->shouldReceive('allow')->andReturnSelf();
-    $throttle->shouldReceive('every')->andReturnSelf();
-    $throttle->shouldReceive('then')->andReturnUsing(
-        fn (callable $success, callable $failure) => $success()
-    );
-    Redis::shouldReceive('throttle')->andReturn($throttle);
 });
 
 it('broadcasts a Finished event when the CV analysis succeeds', function (): void {

--- a/app-modules/candidates/tests/Feature/CompleteOnboardingActionTest.php
+++ b/app-modules/candidates/tests/Feature/CompleteOnboardingActionTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 use He4rt\Candidates\Actions\Onboarding\CompleteOnboardingAction;
 use He4rt\Candidates\DTOs\CandidateOnboardingDTO;
 use He4rt\Candidates\Exceptions\OnboardingException;
+use Illuminate\Support\Facades\Cache;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Prism\Prism\Enums\Provider as ProviderEnum;
+use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Exceptions\PrismRateLimitedException;
 use Prism\Prism\Facades\Prism;
 use Prism\Prism\PrismManager;
@@ -115,6 +117,65 @@ function bindAlwaysRateLimit(): void
     });
 }
 
+/**
+ * Binds a custom PrismManager that throws PrismException on the first call
+ * and returns the given response on subsequent calls.
+ */
+function bindPrismExceptionOnPrimaryThenSuccessOnFallback(StructuredResponse $successResponse): PrismFake
+{
+    $fake = new class($successResponse) extends PrismFake
+    {
+        public int $callCount = 0;
+
+        public function __construct(private readonly StructuredResponse $successResponse) {}
+
+        public function structured(StructuredRequest $request): StructuredResponse
+        {
+            $this->callCount++;
+
+            throw_if($this->callCount === 1, PrismException::class, 'Connection timed out');
+
+            return $this->successResponse;
+        }
+    };
+
+    app()->instance(PrismManager::class, new class($fake) extends PrismManager
+    {
+        public function __construct(private readonly PrismFake $fake) {}
+
+        public function resolve(ProviderEnum|string $name, array $providerConfig = []): PrismFake
+        {
+            return $this->fake;
+        }
+    });
+
+    return $fake;
+}
+
+/** Binds a custom PrismManager that always throws PrismException. */
+function bindAlwaysPrismException(): void
+{
+    $fake = new class extends PrismFake
+    {
+        public function __construct() {}
+
+        public function structured(StructuredRequest $request): StructuredResponse
+        {
+            throw new PrismException('Connection timed out');
+        }
+    };
+
+    app()->instance(PrismManager::class, new class($fake) extends PrismManager
+    {
+        public function __construct(private readonly PrismFake $fake) {}
+
+        public function resolve(ProviderEnum|string $name, array $providerConfig = []): PrismFake
+        {
+            return $this->fake;
+        }
+    });
+}
+
 it('extracts work experiences and education from a valid CV', function (): void {
     Prism::fake([
         StructuredResponseFake::make()->withStructured(onboardingValidCvStructured()),
@@ -156,4 +217,51 @@ it('throws OnboardingException when the uploaded file is not a CV', function ():
 
     expect(fn () => resolve(CompleteOnboardingAction::class)->execute(onboardingMakeFakeFile()))
         ->toThrow(OnboardingException::class);
+});
+
+it('retries with fallback model when primary model throws PrismException', function (): void {
+    Cache::flush();
+
+    $successResponse = StructuredResponseFake::make()->withStructured(onboardingValidCvStructured());
+    $fake = bindPrismExceptionOnPrimaryThenSuccessOnFallback($successResponse);
+
+    $result = resolve(CompleteOnboardingAction::class)->execute(onboardingMakeFakeFile());
+
+    expect($result)->toBeInstanceOf(CandidateOnboardingDTO::class)
+        ->and($fake->callCount)->toBe(2);
+});
+
+it('opens circuit breaker in cache when primary model throws PrismException', function (): void {
+    Cache::flush();
+    $primaryModel = config('ai.provider.gemini.model');
+
+    bindAlwaysPrismException();
+
+    expect(fn () => resolve(CompleteOnboardingAction::class)->execute(onboardingMakeFakeFile()))
+        ->toThrow(OnboardingException::class);
+
+    expect(Cache::has('cb:gemini:'.$primaryModel))->toBeTrue();
+});
+
+it('skips circuit-broken model and goes directly to fallback', function (): void {
+    Cache::flush();
+    $primaryModel = config('ai.provider.gemini.model');
+    $fallbackModel = config('ai.provider.gemini.fallback_model');
+
+    // Pre-activate the circuit breaker for the primary model
+    Cache::put('cb:gemini:'.$primaryModel, true, now()->addMinutes(3));
+
+    // With primary CB active, Prism is only called once (for the fallback).
+    // If primary were NOT skipped, it would throw PrismException and consume this response,
+    // leaving none for the fallback — causing an OnboardingException.
+    Prism::fake([
+        StructuredResponseFake::make()->withStructured(onboardingValidCvStructured()),
+    ]);
+
+    $result = resolve(CompleteOnboardingAction::class)->execute(onboardingMakeFakeFile());
+
+    // Primary CB remains active; fallback CB was never opened (it succeeded)
+    expect($result)->toBeInstanceOf(CandidateOnboardingDTO::class)
+        ->and(Cache::has('cb:gemini:'.$primaryModel))->toBeTrue()
+        ->and(Cache::has('cb:gemini:'.$fallbackModel))->toBeFalse();
 });

--- a/app-modules/candidates/tests/Feature/CompleteOnboardingActionTest.php
+++ b/app-modules/candidates/tests/Feature/CompleteOnboardingActionTest.php
@@ -11,6 +11,7 @@ use Prism\Prism\Enums\Provider as ProviderEnum;
 use Prism\Prism\Exceptions\PrismException;
 use Prism\Prism\Exceptions\PrismProviderOverloadedException;
 use Prism\Prism\Exceptions\PrismRateLimitedException;
+use Prism\Prism\Exceptions\PrismRequestTooLargeException;
 use Prism\Prism\Facades\Prism;
 use Prism\Prism\PrismManager;
 use Prism\Prism\Structured\Request as StructuredRequest;
@@ -177,6 +178,30 @@ function bindAlwaysPrismException(): void
     });
 }
 
+/** Binds a custom PrismManager that always throws PrismRequestTooLargeException. */
+function bindAlwaysRequestTooLarge(): void
+{
+    $fake = new class extends PrismFake
+    {
+        public function __construct() {}
+
+        public function structured(StructuredRequest $request): StructuredResponse
+        {
+            throw new PrismRequestTooLargeException('google');
+        }
+    };
+
+    app()->instance(PrismManager::class, new class($fake) extends PrismManager
+    {
+        public function __construct(private readonly PrismFake $fake) {}
+
+        public function resolve(ProviderEnum|string $name, array $providerConfig = []): PrismFake
+        {
+            return $this->fake;
+        }
+    });
+}
+
 /** Binds a custom PrismManager that always throws PrismProviderOverloadedException. */
 function bindAlwaysProviderOverloaded(): void
 {
@@ -301,4 +326,16 @@ it('skips circuit-broken model and goes directly to fallback', function (): void
     expect($result)->toBeInstanceOf(CandidateOnboardingDTO::class)
         ->and(Cache::has('cb:gemini:'.$primaryModel))->toBeTrue()
         ->and(Cache::has('cb:gemini:'.$fallbackModel))->toBeFalse();
+});
+
+it('does not open circuit breaker when primary model throws PrismRequestTooLargeException', function (): void {
+    Cache::flush();
+    $primaryModel = config('ai.provider.gemini.model');
+
+    bindAlwaysRequestTooLarge();
+
+    expect(fn () => resolve(CompleteOnboardingAction::class)->execute(onboardingMakeFakeFile()))
+        ->toThrow(OnboardingException::class);
+
+    expect(Cache::has('cb:gemini:'.$primaryModel))->toBeFalse();
 });

--- a/app-modules/candidates/tests/Feature/CompleteOnboardingActionTest.php
+++ b/app-modules/candidates/tests/Feature/CompleteOnboardingActionTest.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Cache;
 use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Prism\Prism\Enums\Provider as ProviderEnum;
 use Prism\Prism\Exceptions\PrismException;
+use Prism\Prism\Exceptions\PrismProviderOverloadedException;
 use Prism\Prism\Exceptions\PrismRateLimitedException;
 use Prism\Prism\Facades\Prism;
 use Prism\Prism\PrismManager;
@@ -176,6 +177,30 @@ function bindAlwaysPrismException(): void
     });
 }
 
+/** Binds a custom PrismManager that always throws PrismProviderOverloadedException. */
+function bindAlwaysProviderOverloaded(): void
+{
+    $fake = new class extends PrismFake
+    {
+        public function __construct() {}
+
+        public function structured(StructuredRequest $request): StructuredResponse
+        {
+            throw new PrismProviderOverloadedException('Provider overloaded');
+        }
+    };
+
+    app()->instance(PrismManager::class, new class($fake) extends PrismManager
+    {
+        public function __construct(private readonly PrismFake $fake) {}
+
+        public function resolve(ProviderEnum|string $name, array $providerConfig = []): PrismFake
+        {
+            return $this->fake;
+        }
+    });
+}
+
 it('extracts work experiences and education from a valid CV', function (): void {
     Prism::fake([
         StructuredResponseFake::make()->withStructured(onboardingValidCvStructured()),
@@ -231,11 +256,23 @@ it('retries with fallback model when primary model throws PrismException', funct
         ->and($fake->callCount)->toBe(2);
 });
 
-it('opens circuit breaker in cache when primary model throws PrismException', function (): void {
+it('does not open circuit breaker when primary model throws generic PrismException', function (): void {
     Cache::flush();
     $primaryModel = config('ai.provider.gemini.model');
 
     bindAlwaysPrismException();
+
+    expect(fn () => resolve(CompleteOnboardingAction::class)->execute(onboardingMakeFakeFile()))
+        ->toThrow(OnboardingException::class);
+
+    expect(Cache::has('cb:gemini:'.$primaryModel))->toBeFalse();
+});
+
+it('opens circuit breaker when primary model throws PrismProviderOverloadedException', function (): void {
+    Cache::flush();
+    $primaryModel = config('ai.provider.gemini.model');
+
+    bindAlwaysProviderOverloaded();
 
     expect(fn () => resolve(CompleteOnboardingAction::class)->execute(onboardingMakeFakeFile()))
         ->toThrow(OnboardingException::class);


### PR DESCRIPTION
## Problema

Entre os dias 01/04 e 03/04, o processo de análise automática de CV via Gemini começou a falhar silenciosamente por dois motivos distintos:

- **cURL error 28 (timeout):** a conexão expirava após 30s sem resposta do modelo
- **Gemini overloaded (503):** a API retornava sobrecarga explicitamente

Em ambos os casos, o sistema capturava qualquer `PrismException` no `callWithFallback`, descartava o modelo fallback **sem sequer tentá-lo**, e lançava `OnboardingException::rateLimiting`. O job capturava essa exceção, fazia o broadcast de erro para o WebSocket e encerrava normalmente — o sistema de filas nunca via a exceção e nunca retentava. O usuário recebia um erro imediato no formulário sem segunda chance.

---

## O que foi feito

### Timeout do cliente HTTP Prism (`CompleteOnboardingAction`)

O Prism usa `config('prism.request_timeout')` (padrão: **30s**) como timeout do cURL — exatamente o valor do erro reportado. O `$timeout = 90` definido no Job controla o timeout do *queue worker*, não da requisição HTTP.

A chamada ao Prism em `callPrism()` agora usa `->withClientOptions()` para sobrescrever os timeouts apenas para análise de CV:

```php
Prism::structured()
    ->using($provider, $model)
    ->withClientOptions(['timeout' => 90, 'connect_timeout' => 10])
    ->withSchema(...)
```

- `timeout: 90` — aguarda até 90s pela resposta do Gemini, alinhado com o `$timeout` do Job
- `connect_timeout: 10` — falha rápido se a API estiver inacessível, sem bloquear o circuit breaker por 90s desnecessariamente

### Circuit Breaker por modelo (`CompleteOnboardingAction`)

- Antes de chamar cada modelo, o método `callWithFallback` consulta o cache pela chave `cb:gemini:{model}`
- Se a chave existir (CB ativo), o modelo é pulado sem chamada à API
- Qualquer falha (`PrismException` ou `PrismRateLimitedException`) agora abre o circuit breaker para aquele modelo no cache com TTL de 3 minutos e faz `continue` para o próximo — em vez de lançar imediatamente
- Resultado: timeout no modelo primário → tenta o fallback na mesma execução do job

### Retry leve com backoff (`AiAnalyzeResumeJob`)

- `tries() = 2` com `backoff() = [15]` (15 segundos entre tentativas)
- Erros transitórios (HTTP 503) agora são **re-thrown**, permitindo que a fila do Laravel faça o retry automaticamente
- Erros permanentes (HTTP 422 — arquivo não é CV) continuam com broadcast imediato de erro sem retry
- `$timeout = 90` para dar margem ao Gemini responder

### Throttle de concorrência via job middleware (`AiAnalyzeResumeJob`)

Limita o número de execuções simultâneas para evitar auto-overload da API Gemini. Utiliza o middleware nativo `RateLimited` do Laravel, registrado no `CandidatesServiceProvider`:

```php
RateLimiter::for('gemini-cv-analysis', fn () => new Limit(maxAttempts: 3, decaySeconds: 10));
```

```php
public function middleware(): array
{
    return [new RateLimited('gemini-cv-analysis')];
}
```

O `RateLimited` middleware usa o `RateLimiter` facade, que opera sobre o **cache store configurado** (não sobre Redis diretamente). Isso significa que em CI e testes com `CACHE_STORE=database` ou `array`, nenhuma conexão Redis é feita — ao contrário de `Redis::throttle()` que abre conexão direta independentemente do ambiente.

### `failed()` para falha definitiva

- Após esgotar as tentativas, o método `failed()` faz o broadcast de erro ao WebSocket com a mensagem existente de `rate_limit.body` — que orienta o usuário a preencher manualmente ou reenviar pelo perfil
- A exceção é reportada via `report_if()` para monitoramento

### Logs estruturados

- Logs de warning/error em todos os pontos de falha: circuit breaker ativo, erro Prism, falha transitória, falha definitiva
- Contexto inclui: `userId`, `attempt`, `model`, `circuit_key`, `error`, `exception`

---

## Testes

Cobertura adicionada em `AiAnalyzeResumeJobTest` e `CompleteOnboardingActionTest`:

- Sucesso na análise → broadcast `Finished`
- Arquivo inválido (422) → broadcast `Error` imediato, sem retry
- Falha transitória (503) → exceção re-thrown para queue retry, sem broadcast
- `failed()` após esgotar tentativas → broadcast `Error` com HTTP 503
- `PrismException` abre circuit breaker no cache para o modelo falho
- Modelo com CB ativo é skipado, fallback é chamado diretamente

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resume analysis resilience: retries, timeouts, clearer transient vs permanent error handling, and a circuit-breaker to skip failing AI models.

* **New Features / Chores**
  * Updated default AI model and fallback values in configuration templates.
  * Added rate-limiting and queue execution controls for resume analysis jobs.
  * Adjusted test DB setup and removed many per-module test targets from the Makefile.

* **Tests**
  * Expanded tests covering AI failure modes, retry/circuit-breaker behavior, and job failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->