### PR TITLE
fix: invite team member

### DIFF
--- a/app-modules/panel-admin/src/Filament/Resources/Teams/RelationManagers/MembersRelationManager.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Teams/RelationManagers/MembersRelationManager.php
@@ -17,6 +17,7 @@ use Filament\Tables\Table;
 use He4rt\Admin\Filament\Resources\Users\UserResource;
 use He4rt\Teams\Actions\NewMember\InviteTeamMemberAction;
 use He4rt\Teams\Actions\NewMember\InviteTeamMemberDTO;
+use He4rt\Teams\Actions\NewMember\InviteTeamMemberResult;
 use He4rt\Teams\Team;
 use Illuminate\Database\Eloquent\Model;
 
@@ -65,11 +66,21 @@ class MembersRelationManager extends RelationManager
 
                         return $data;
                     })
-                    ->action(function (array $data): void {
-
-                        resolve(InviteTeamMemberAction::class)->handle(
+                    ->action(function (array $data, Action $action): void {
+                        $result = resolve(InviteTeamMemberAction::class)->handle(
                             InviteTeamMemberDTO::fromArray($data)
                         );
+
+                        if ($result === InviteTeamMemberResult::AlreadyMember) {
+                            Notification::make()
+                                ->title(__('teams::filament.relation_managers.members.invite_already_member'))
+                                ->warning()
+                                ->send();
+
+                            $action->halt();
+
+                            return;
+                        }
 
                         Notification::make()
                             ->title(__('teams::filament.relation_managers.members.invite_success'))

--- a/app-modules/panel-admin/tests/Feature/Filament/MembersRelationManagerTest.php
+++ b/app-modules/panel-admin/tests/Feature/Filament/MembersRelationManagerTest.php
@@ -50,6 +50,49 @@ test('invite action creates user, attaches to team and dispatches job', function
     );
 });
 
+test('invite action adds existing user to team without dispatching job', function (): void {
+    Bus::fake();
+
+    $team = Team::factory()->create();
+    $existingUser = User::factory()->create(['email' => 'existing@example.com']);
+
+    livewire(MembersRelationManager::class, [
+        'ownerRecord' => $team,
+        'pageClass' => EditTeam::class,
+    ])
+        ->callAction(TestAction::make('invite')->table(), data: [
+            'name' => $existingUser->name,
+            'email' => 'existing@example.com',
+        ])
+        ->assertHasNoActionErrors()
+        ->assertNotified(__('teams::filament.relation_managers.members.invite_success'));
+
+    expect($team->fresh()->members->contains($existingUser))->toBeTrue();
+
+    Bus::assertNotDispatched(SendTeamInvitationJob::class);
+});
+
+test('invite action shows warning and halts when user is already a member', function (): void {
+    Bus::fake();
+
+    $team = Team::factory()->create();
+    $existingMember = User::factory()->create(['email' => 'member@example.com']);
+    $team->members()->syncWithoutDetaching($existingMember->getKey());
+
+    livewire(MembersRelationManager::class, [
+        'ownerRecord' => $team,
+        'pageClass' => EditTeam::class,
+    ])
+        ->callAction(TestAction::make('invite')->table(), data: [
+            'name' => $existingMember->name,
+            'email' => 'member@example.com',
+        ])
+        ->assertActionHalted(TestAction::make('invite')->table())
+        ->assertNotified(__('teams::filament.relation_managers.members.invite_already_member'));
+
+    Bus::assertNotDispatched(SendTeamInvitationJob::class);
+});
+
 test('invite modal does not expose a password field', function (): void {
     $team = Team::factory()->create();
 

--- a/app-modules/teams/lang/en/filament.php
+++ b/app-modules/teams/lang/en/filament.php
@@ -39,6 +39,7 @@ return [
             'invite_heading' => 'Invite New Member',
             'invite_description' => 'Create a new user and add them to this team.',
             'invite_success' => 'Invitation sent successfully!',
+            'invite_already_member' => 'This user is already a member of this team.',
         ],
         'departments' => [
             'title' => 'Departments',

--- a/app-modules/teams/lang/pt_BR/filament.php
+++ b/app-modules/teams/lang/pt_BR/filament.php
@@ -39,6 +39,7 @@ return [
             'invite_heading' => 'Convidar Novo Membro',
             'invite_description' => 'Criar um novo usuário e adicioná-lo a este time.',
             'invite_success' => 'Convite enviado com sucesso!',
+            'invite_already_member' => 'Este usuário já é membro deste time.',
         ],
         'departments' => [
             'title' => 'Departamentos',

--- a/app-modules/teams/src/Actions/NewMember/InviteTeamMemberAction.php
+++ b/app-modules/teams/src/Actions/NewMember/InviteTeamMemberAction.php
@@ -9,14 +9,32 @@ use He4rt\Users\User;
 
 class InviteTeamMemberAction
 {
-    public function handle(InviteTeamMemberDTO $inviteTeamMemberDTO): void
+    public function handle(InviteTeamMemberDTO $dto): InviteTeamMemberResult
     {
-        $user = User::query()->create($inviteTeamMemberDTO->jsonSerialize());
+        $team = Team::query()->findOrFail($dto->teamId);
 
-        $team = Team::query()->findOrFail($inviteTeamMemberDTO->teamId);
+        /** @var User $user */
+        $user = User::query()->firstOrNew(['email' => $dto->email]);
+        $isNewUser = ! $user->exists;
+
+        if ($isNewUser) {
+            $user->fill($dto->jsonSerialize())->save();
+        }
+
+        $alreadyMember = $team->members()->where('user_id', $user->getKey())->exists();
+
+        if ($alreadyMember) {
+            return InviteTeamMemberResult::AlreadyMember;
+        }
 
         $team->members()->syncWithoutDetaching($user->getKey());
 
-        dispatch(new SendTeamInvitationJob($user, $team));
+        if ($isNewUser) {
+            dispatch(new SendTeamInvitationJob($user, $team));
+        }
+
+        return $isNewUser
+            ? InviteTeamMemberResult::NewUserInvited
+            : InviteTeamMemberResult::ExistingUserAdded;
     }
 }

--- a/app-modules/teams/src/Actions/NewMember/InviteTeamMemberResult.php
+++ b/app-modules/teams/src/Actions/NewMember/InviteTeamMemberResult.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Teams\Actions\NewMember;
+
+enum InviteTeamMemberResult
+{
+    /** New user was created, added to the team, and an invitation e-mail was dispatched. */
+    case NewUserInvited;
+
+    /** An existing user was added to the team. No e-mail was sent. */
+    case ExistingUserAdded;
+
+    /** The user was already a member of the team. No changes were made. */
+    case AlreadyMember;
+}

--- a/app-modules/teams/tests/Features/Actions/NewMember/InviteTeamMemberActionTest.php
+++ b/app-modules/teams/tests/Features/Actions/NewMember/InviteTeamMemberActionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use He4rt\Recruitment\Staff\Recruiter\Recruiter;
 use He4rt\Teams\Actions\NewMember\InviteTeamMemberAction;
 use He4rt\Teams\Actions\NewMember\InviteTeamMemberDTO;
+use He4rt\Teams\Actions\NewMember\InviteTeamMemberResult;
 use He4rt\Teams\Actions\NewMember\SendTeamInvitationJob;
 use He4rt\Teams\Team;
 use He4rt\Users\User;
@@ -22,8 +23,9 @@ test('it creates a user and attaches it to a team and dispatches invitation job'
         email: 'newmember@example.com'
     );
 
-    $action = new InviteTeamMemberAction();
-    $action->handle($dto);
+    $result = new InviteTeamMemberAction()->handle($dto);
+
+    expect($result)->toBe(InviteTeamMemberResult::NewUserInvited);
 
     assertDatabaseHas('users', [
         'name' => 'New Member',
@@ -37,7 +39,47 @@ test('it creates a user and attaches it to a team and dispatches invitation job'
     Bus::assertDispatched(fn (SendTeamInvitationJob $job) => $job->user->is($user) && $job->team->is($team));
 });
 
-test('inviting a team member auto-creates a recruiter record for them', function (): void {
+test('existing user is added to team without sending an invitation e-mail', function (): void {
+    Bus::fake();
+
+    $team = Team::factory()->create();
+    $existingUser = User::factory()->create(['email' => 'existing@example.com']);
+
+    $dto = new InviteTeamMemberDTO(
+        teamId: (string) $team->id,
+        name: $existingUser->name,
+        email: 'existing@example.com'
+    );
+
+    $result = new InviteTeamMemberAction()->handle($dto);
+
+    expect($result)->toBe(InviteTeamMemberResult::ExistingUserAdded)
+        ->and($team->fresh()->members->contains($existingUser))->toBeTrue();
+
+    Bus::assertNotDispatched(SendTeamInvitationJob::class);
+});
+
+test('returns AlreadyMember when user is already part of the team', function (): void {
+    Bus::fake();
+
+    $team = Team::factory()->create();
+    $existingUser = User::factory()->create(['email' => 'already@example.com']);
+    $team->members()->syncWithoutDetaching($existingUser->getKey());
+
+    $dto = new InviteTeamMemberDTO(
+        teamId: (string) $team->id,
+        name: $existingUser->name,
+        email: 'already@example.com'
+    );
+
+    $result = new InviteTeamMemberAction()->handle($dto);
+
+    expect($result)->toBe(InviteTeamMemberResult::AlreadyMember);
+
+    Bus::assertNotDispatched(SendTeamInvitationJob::class);
+});
+
+test('inviting a new team member auto-creates a recruiter record for them', function (): void {
     Bus::fake();
 
     $team = Team::factory()->create();
@@ -47,8 +89,7 @@ test('inviting a team member auto-creates a recruiter record for them', function
         email: 'recruiter@example.com'
     );
 
-    $action = new InviteTeamMemberAction();
-    $action->handle($dto);
+    new InviteTeamMemberAction()->handle($dto);
 
     $user = User::query()->where('email', 'recruiter@example.com')->first();
 
@@ -69,8 +110,7 @@ test('inviting the same member twice does not create duplicate recruiter records
         email: 'recruiter-dupe@example.com'
     );
 
-    $action = new InviteTeamMemberAction();
-    $action->handle($dto);
+    new InviteTeamMemberAction()->handle($dto);
 
     $user = User::query()->where('email', 'recruiter-dupe@example.com')->first();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to prevent inviting users already on the team; users receive a clear notification when attempting duplicate invitations.

* **Bug Fixes**
  * Improved handling of existing users when adding them to teams.

* **Documentation**
  * Added localized messages in English and Portuguese (pt_BR) to inform users when an invitee is already a team member.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->