### PR TITLE
feat(panel-app): order job recommendations alphabetically by post title

### DIFF
--- a/app-modules/panel-app/src/Livewire/JobRecommendations.php
+++ b/app-modules/panel-app/src/Livewire/JobRecommendations.php
@@ -6,6 +6,7 @@ namespace He4rt\App\Livewire;
 
 use He4rt\Recruitment\Requisitions\Enums\EmploymentTypeEnum;
 use He4rt\Recruitment\Requisitions\Enums\RequisitionStatusEnum;
+use He4rt\Recruitment\Requisitions\Models\JobPosting;
 use He4rt\Recruitment\Requisitions\Models\JobRequisition;
 use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Contracts\View\View;
@@ -44,7 +45,10 @@ class JobRecommendations extends Component
             ->where('status', RequisitionStatusEnum::Published->value)
             ->when($this->search, fn ($q) => $q->whereHas('post', fn (Builder $p) => $p->where('title', 'like', sprintf('%%%s%%', $this->search))))
             ->unless($this->jobTypes === [], fn ($q) => $q->whereIn('employment_type', $this->normalizedJobTypes()))
-            ->latest()
+            ->orderBy(
+                JobPosting::query()->select('title')
+                    ->whereColumn('job_requisition_id', 'recruitment_job_requisitions.id')
+            )
             ->paginate(12);
     }
 


### PR DESCRIPTION
Replaces the default `latest()` ordering on the public job recommendations listing with a correlated subquery on `recruitment_job_postings.title`, producing a stable alphabetical sort that doesn't break `withCount('applications')`.

Ref: RPQ - STORY - 75 | Organizar listagem de vagas em ordem alfabética https://3pontos.monday.com/boards/18392609686/pulses/11979994341

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Job recommendations are now ordered alphabetically by job title for improved organization and discoverability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/3pontos-tech/recruit-party-quest/pull/151)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->