### PR TITLE
feat(panel-app): skip onboarding for super admin and admin

### DIFF
--- a/app-modules/panel-app/src/RedirectIfOnboardingIncomplete.php
+++ b/app-modules/panel-app/src/RedirectIfOnboardingIncomplete.php
@@ -7,6 +7,7 @@ namespace He4rt\App;
 use Closure;
 use He4rt\App\Filament\Pages\OnboardingWizard;
 use He4rt\Candidates\Models\Candidate;
+use He4rt\Permissions\Roles;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -19,6 +20,10 @@ class RedirectIfOnboardingIncomplete
         }
 
         if ($request->routeIs('filament.app.auth.logout') || $request->routeIs('filament.app.auth.*')) {
+            return $next($request);
+        }
+
+        if ($request->user()->hasAnyRole([Roles::SuperAdmin, Roles::Admin])) {
             return $next($request);
         }
 

--- a/app-modules/panel-app/tests/Feature/RedirectIfOnboardingIncompleteTest.php
+++ b/app-modules/panel-app/tests/Feature/RedirectIfOnboardingIncompleteTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\FilamentPanel;
+use He4rt\App\Filament\Pages\AppDashboard;
+use He4rt\App\Filament\Pages\LandingPage;
+use He4rt\App\Filament\Pages\OnboardingWizard;
+use He4rt\Permissions\Roles;
+use He4rt\Users\User;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Laravel\get;
+
+beforeEach(function (): void {
+    filament()->setCurrentPanel(FilamentPanel::App->value);
+});
+
+it('redirects an authenticated candidate with incomplete onboarding to the wizard', function (): void {
+    $user = User::factory()->create();
+
+    actingAs($user);
+
+    get(AppDashboard::getUrl())
+        ->assertRedirect(OnboardingWizard::getUrl());
+});
+
+it('redirects a guest to the landing page instead of the onboarding wizard', function (): void {
+    get(AppDashboard::getUrl())
+        ->assertRedirect(LandingPage::getUrl());
+});
+
+it('does not force onboarding for a super admin', function (): void {
+    $user = User::factory()->admin()->create();
+
+    actingAs($user);
+
+    get(AppDashboard::getUrl())
+        ->assertOk();
+});
+
+it('does not force onboarding for an admin', function (): void {
+    $user = User::factory()->create();
+    $user->assignRole(Roles::Admin);
+
+    actingAs($user);
+
+    get(AppDashboard::getUrl())
+        ->assertOk();
+});
+
+it('still forces onboarding for a plain user role', function (): void {
+    $user = User::factory()->create();
+
+    actingAs($user);
+
+    expect($user->fresh()->hasAnyRole([Roles::SuperAdmin, Roles::Admin]))->toBeFalse();
+
+    get(AppDashboard::getUrl())
+        ->assertRedirect(OnboardingWizard::getUrl());
+});


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Admin and Super Admin users are now exempt from mandatory onboarding requirements and can access the app dashboard directly after authentication.

* **Tests**
  * Added test suite validating onboarding redirect behavior across multiple user scenarios, including authenticated users with incomplete onboarding, unauthenticated guests, and role-based access control exemptions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/3pontos-tech/recruit-party-quest/pull/153)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->