### PR TITLE
feat: rpq story 79

### DIFF
--- a/app-modules/panel-organization/lang/en/filament.php
+++ b/app-modules/panel-organization/lang/en/filament.php
@@ -78,6 +78,19 @@ return [
             'success_body' => 'The AI has generated your job requisition and posting. Review and edit as needed before publishing.',
             'error_title' => 'Generation Failed',
         ],
+        'duplicate_job_requisition' => [
+            'label' => 'Duplicate',
+            'modal_heading' => 'Duplicate Job',
+            'modal_description' => 'A new draft will be created with the same structure (posting, requirements, pipeline stages and screening questions). Applications, comments and evaluations will not be copied.',
+            'notification' => 'Job duplicated successfully',
+            'title_suffix' => '(Copy)',
+            'bulk' => [
+                'label' => 'Duplicate selected',
+                'modal_heading' => 'Duplicate selected jobs',
+                'modal_description' => 'A new draft will be created for each selected job, keeping the same structure. Applications, comments and evaluations will not be copied.',
+                'notification' => ':count job(s) duplicated successfully',
+            ],
+        ],
     ],
 
     'notifications' => [

--- a/app-modules/panel-organization/lang/pt_BR/filament.php
+++ b/app-modules/panel-organization/lang/pt_BR/filament.php
@@ -79,6 +79,19 @@ return [
             'success_body' => 'A IA gerou sua requisição e anúncio de vaga. Revise e edite conforme necessário antes de publicar.',
             'error_title' => 'Falha na Geração',
         ],
+        'duplicate_job_requisition' => [
+            'label' => 'Duplicar',
+            'modal_heading' => 'Duplicar Vaga',
+            'modal_description' => 'Será criado um novo rascunho com a mesma estrutura (anúncio, requisitos, etapas do pipeline e perguntas de triagem). Candidaturas, comentários e avaliações não serão copiados.',
+            'notification' => 'Vaga duplicada com sucesso',
+            'title_suffix' => '(Cópia)',
+            'bulk' => [
+                'label' => 'Duplicar selecionadas',
+                'modal_heading' => 'Duplicar vagas selecionadas',
+                'modal_description' => 'Será criado um novo rascunho para cada vaga selecionada, mantendo a mesma estrutura. Candidaturas, comentários e avaliações não serão copiados.',
+                'notification' => ':count vaga(s) duplicada(s) com sucesso',
+            ],
+        ],
     ],
 
     'notifications' => [

--- a/app-modules/panel-organization/src/Filament/Resources/Recruitment/JobRequisitions/Actions/DuplicateJobRequisitionAction.php
+++ b/app-modules/panel-organization/src/Filament/Resources/Recruitment/JobRequisitions/Actions/DuplicateJobRequisitionAction.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Organization\Filament\Resources\Recruitment\JobRequisitions\Actions;
+
+use Filament\Actions\Action;
+use Filament\Notifications\Notification;
+use Filament\Support\Icons\Heroicon;
+use He4rt\Organization\Filament\Resources\Recruitment\JobRequisitions\JobRequisitionResource;
+use He4rt\Recruitment\Requisitions\Actions\DuplicateJobRequisitionAction as DuplicateJobRequisition;
+use He4rt\Recruitment\Requisitions\Models\JobRequisition;
+
+class DuplicateJobRequisitionAction extends Action
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this
+            ->label(__('panel-organization::filament.actions.duplicate_job_requisition.label'))
+            ->icon(Heroicon::OutlinedDocumentDuplicate)
+            ->authorize('create')
+            ->visible(fn (JobRequisition $record): bool => ! $record->trashed())
+            ->requiresConfirmation()
+            ->modalIcon(Heroicon::OutlinedDocumentDuplicate)
+            ->modalHeading(__('panel-organization::filament.actions.duplicate_job_requisition.modal_heading'))
+            ->modalDescription(__('panel-organization::filament.actions.duplicate_job_requisition.modal_description'))
+            ->action(function (JobRequisition $record): void {
+                $duplicate = resolve(DuplicateJobRequisition::class)->execute($record, (string) auth()->id());
+
+                Notification::make()
+                    ->success()
+                    ->title(__('panel-organization::filament.actions.duplicate_job_requisition.notification'))
+                    ->send();
+
+                redirect(JobRequisitionResource::getUrl('edit', ['record' => $duplicate]));
+            });
+    }
+
+    public static function getDefaultName(): ?string
+    {
+        return 'duplicate';
+    }
+}

--- a/app-modules/panel-organization/src/Filament/Resources/Recruitment/JobRequisitions/Actions/DuplicateJobRequisitionBulkAction.php
+++ b/app-modules/panel-organization/src/Filament/Resources/Recruitment/JobRequisitions/Actions/DuplicateJobRequisitionBulkAction.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Organization\Filament\Resources\Recruitment\JobRequisitions\Actions;
+
+use Filament\Actions\BulkAction;
+use Filament\Notifications\Notification;
+use Filament\Support\Icons\Heroicon;
+use He4rt\Recruitment\Requisitions\Actions\DuplicateJobRequisitionAction as DuplicateJobRequisition;
+use He4rt\Recruitment\Requisitions\Models\JobRequisition;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\DB;
+
+class DuplicateJobRequisitionBulkAction extends BulkAction
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this
+            ->label(__('panel-organization::filament.actions.duplicate_job_requisition.bulk.label'))
+            ->icon(Heroicon::OutlinedDocumentDuplicate)
+            ->authorize('create')
+            ->requiresConfirmation()
+            ->modalIcon(Heroicon::OutlinedDocumentDuplicate)
+            ->modalHeading(__('panel-organization::filament.actions.duplicate_job_requisition.bulk.modal_heading'))
+            ->modalDescription(__('panel-organization::filament.actions.duplicate_job_requisition.bulk.modal_description'))
+            ->deselectRecordsAfterCompletion()
+            ->action(function (Collection $records): void {
+                $duplicator = resolve(DuplicateJobRequisition::class);
+                $createdById = (string) auth()->id();
+
+                $duplicatable = $records
+                    ->whereInstanceOf(JobRequisition::class)
+                    ->reject->trashed();
+
+                DB::transaction(fn () => $duplicatable->each(
+                    fn (JobRequisition $record) => $duplicator->execute($record, $createdById),
+                ));
+
+                Notification::make()
+                    ->success()
+                    ->title(__('panel-organization::filament.actions.duplicate_job_requisition.bulk.notification', [
+                        'count' => $duplicatable->count(),
+                    ]))
+                    ->send();
+            });
+    }
+
+    public static function getDefaultName(): ?string
+    {
+        return 'duplicate';
+    }
+}

--- a/app-modules/panel-organization/src/Filament/Resources/Recruitment/JobRequisitions/Pages/EditJobRequisition.php
+++ b/app-modules/panel-organization/src/Filament/Resources/Recruitment/JobRequisitions/Pages/EditJobRequisition.php
@@ -8,6 +8,7 @@ use Filament\Actions\DeleteAction;
 use Filament\Actions\ForceDeleteAction;
 use Filament\Actions\RestoreAction;
 use Filament\Resources\Pages\EditRecord;
+use He4rt\Organization\Filament\Resources\Recruitment\JobRequisitions\Actions\DuplicateJobRequisitionAction;
 use He4rt\Organization\Filament\Resources\Recruitment\JobRequisitions\JobRequisitionResource;
 use He4rt\Recruitment\Requisitions\Models\JobRequisition;
 use Illuminate\Contracts\Support\Htmlable;
@@ -27,6 +28,7 @@ class EditJobRequisition extends EditRecord
     protected function getHeaderActions(): array
     {
         return [
+            DuplicateJobRequisitionAction::make(),
             DeleteAction::make(),
             ForceDeleteAction::make(),
             RestoreAction::make(),

--- a/app-modules/panel-organization/src/Filament/Resources/Recruitment/JobRequisitions/Pages/ViewJobRequisition.php
+++ b/app-modules/panel-organization/src/Filament/Resources/Recruitment/JobRequisitions/Pages/ViewJobRequisition.php
@@ -6,6 +6,7 @@ namespace He4rt\Organization\Filament\Resources\Recruitment\JobRequisitions\Page
 
 use Filament\Resources\Pages\ViewRecord;
 use Filament\Schemas\Schema;
+use He4rt\Organization\Filament\Resources\Recruitment\JobRequisitions\Actions\DuplicateJobRequisitionAction;
 use He4rt\Organization\Filament\Resources\Recruitment\JobRequisitions\JobRequisitionResource;
 use He4rt\Organization\Filament\Resources\Recruitment\JobRequisitions\Schemas\JobRequisitionInfolist;
 use He4rt\Recruitment\Requisitions\Models\JobRequisition;
@@ -26,5 +27,12 @@ class ViewJobRequisition extends ViewRecord
     public function infolist(Schema $schema): Schema
     {
         return JobRequisitionInfolist::configure($schema);
+    }
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DuplicateJobRequisitionAction::make(),
+        ];
     }
 }

--- a/app-modules/panel-organization/src/Filament/Resources/Recruitment/JobRequisitions/Tables/JobRequisitionsTable.php
+++ b/app-modules/panel-organization/src/Filament/Resources/Recruitment/JobRequisitions/Tables/JobRequisitionsTable.php
@@ -19,6 +19,8 @@ use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Filters\TernaryFilter;
 use Filament\Tables\Filters\TrashedFilter;
 use Filament\Tables\Table;
+use He4rt\Organization\Filament\Resources\Recruitment\JobRequisitions\Actions\DuplicateJobRequisitionAction;
+use He4rt\Organization\Filament\Resources\Recruitment\JobRequisitions\Actions\DuplicateJobRequisitionBulkAction;
 use He4rt\Organization\Filament\Resources\Recruitment\JobRequisitions\JobRequisitionResource;
 use He4rt\Permissions\Roles;
 use He4rt\Recruitment\Requisitions\Enums\EmploymentTypeEnum;
@@ -112,12 +114,15 @@ class JobRequisitionsTable
                     Action::make('kanban')
                         ->label(__('panel-organization::filament.tables.kanban'))
                         ->icon(Heroicon::OutlinedViewColumns)
-                        ->url(fn (JobRequisition $record): string => JobRequisitionResource::getUrl('kanban', ['record' => $record->id])),
+                        ->url(fn (JobRequisition $record): string => JobRequisitionResource::getUrl('kanban',
+                            ['record' => $record->id])),
+                    DuplicateJobRequisitionAction::make(),
                 ]),
             ])
             ->defaultSort('published_at', 'desc')
             ->toolbarActions([
                 BulkActionGroup::make([
+                    DuplicateJobRequisitionBulkAction::make(),
                     DeleteBulkAction::make(),
                     ForceDeleteBulkAction::make(),
                     RestoreBulkAction::make(),

--- a/app-modules/panel-organization/tests/Feature/JobRequisition/DuplicateJobRequisitionTest.php
+++ b/app-modules/panel-organization/tests/Feature/JobRequisition/DuplicateJobRequisitionTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\FilamentPanel;
+use Filament\Actions\Testing\TestAction;
+use He4rt\Applications\Models\Application;
+use He4rt\Organization\Filament\Resources\Recruitment\JobRequisitions\Actions\DuplicateJobRequisitionAction;
+use He4rt\Organization\Filament\Resources\Recruitment\JobRequisitions\JobRequisitionResource;
+use He4rt\Organization\Filament\Resources\Recruitment\JobRequisitions\Pages\EditJobRequisition;
+use He4rt\Organization\Filament\Resources\Recruitment\JobRequisitions\Pages\ListJobRequisitions;
+use He4rt\Permissions\Roles;
+use He4rt\Recruitment\Requisitions\Enums\RequisitionStatusEnum;
+use He4rt\Recruitment\Requisitions\Models\JobPosting;
+use He4rt\Recruitment\Requisitions\Models\JobRequisition;
+use He4rt\Recruitment\Staff\Recruiter\Recruiter;
+use He4rt\Teams\Department;
+use Livewire\Livewire;
+
+use function Pest\Laravel\actingAs;
+
+beforeEach(function (): void {
+    filament()->setCurrentPanel(FilamentPanel::Organization->value);
+    $this->recruiter = Recruiter::factory()->createOne();
+    actingAs($this->recruiter->user);
+    $this->team = $this->recruiter->team;
+    $this->department = Department::factory()->forRecruiter($this->recruiter)->createOne();
+    filament()->setTenant($this->team);
+
+    $this->jobRequisition = JobRequisition::factory()
+        ->for($this->team)
+        ->for($this->department)
+        ->for($this->recruiter, 'recruiter')
+        ->for($this->recruiter->user, 'createdBy')
+        ->create(['status' => RequisitionStatusEnum::Published]);
+
+    $this->jobPosting = JobPosting::factory()
+        ->for($this->jobRequisition, 'jobRequisition')
+        ->create();
+});
+
+it('duplicates a job requisition from the table and redirects to the new draft', function (): void {
+    $this->recruiter->user->givePermissionTo('create_job_requisitions');
+
+    $component = Livewire::test(ListJobRequisitions::class)
+        ->callAction(TestAction::make('duplicate')->table($this->jobRequisition))
+        ->assertHasNoActionErrors();
+
+    $duplicate = JobRequisition::query()->whereKeyNot($this->jobRequisition->getKey())->sole();
+
+    expect($duplicate->status)->toBe(RequisitionStatusEnum::Draft)
+        ->and($duplicate->created_by_id)->toBe($this->recruiter->user->getKey())
+        ->and($duplicate->team_id)->toBe($this->team->getKey());
+
+    $component->assertRedirect(JobRequisitionResource::getUrl('edit', ['record' => $duplicate]));
+});
+
+it('duplicates a job requisition from the edit page header action', function (): void {
+    $this->recruiter->user->givePermissionTo('update_job_requisitions');
+    $this->recruiter->user->givePermissionTo('create_job_requisitions');
+
+    Livewire::test(EditJobRequisition::class, ['record' => $this->jobRequisition->getKey()])
+        ->callAction(DuplicateJobRequisitionAction::class)
+        ->assertHasNoActionErrors();
+
+    expect(JobRequisition::query()->whereKeyNot($this->jobRequisition->getKey())->sole()->status)
+        ->toBe(RequisitionStatusEnum::Draft);
+});
+
+it('hides the duplicate action when the user lacks the create permission', function (): void {
+    Livewire::test(ListJobRequisitions::class)
+        ->assertActionHidden(TestAction::make('duplicate')->table($this->jobRequisition));
+});
+
+it('hides the duplicate action for trashed requisitions', function (): void {
+    $this->recruiter->user->givePermissionTo('create_job_requisitions');
+    $this->jobRequisition->delete();
+
+    Livewire::test(ListJobRequisitions::class)
+        ->filterTable('trashed')
+        ->assertActionHidden(TestAction::make('duplicate')->table($this->jobRequisition));
+});
+
+it('does not copy applications when duplicating', function (): void {
+    $this->recruiter->user->givePermissionTo('create_job_requisitions');
+    Application::factory()->for($this->jobRequisition, 'requisition')->create();
+
+    Livewire::test(ListJobRequisitions::class)
+        ->callAction(TestAction::make('duplicate')->table($this->jobRequisition))
+        ->assertHasNoActionErrors();
+
+    $duplicate = JobRequisition::query()->whereKeyNot($this->jobRequisition->getKey())->sole();
+
+    expect($duplicate->applications()->count())->toBe(0);
+});
+
+it('bulk-duplicates the selected job requisitions as drafts', function (): void {
+    $this->recruiter->user->assignRole(Roles::SuperAdmin->value);
+    $this->recruiter->user->givePermissionTo('create_job_requisitions');
+
+    $other = JobRequisition::factory()
+        ->for($this->team)
+        ->for($this->department)
+        ->for($this->recruiter, 'recruiter')
+        ->for($this->recruiter->user, 'createdBy')
+        ->create(['status' => RequisitionStatusEnum::Published]);
+
+    JobPosting::factory()->for($other, 'jobRequisition')->create();
+
+    Livewire::test(ListJobRequisitions::class)
+        ->selectTableRecords([$this->jobRequisition->getKey(), $other->getKey()])
+        ->callAction(TestAction::make('duplicate')->table()->bulk())
+        ->assertHasNoActionErrors();
+
+    $duplicates = JobRequisition::query()
+        ->whereNotIn('id', [$this->jobRequisition->getKey(), $other->getKey()])
+        ->get();
+
+    expect($duplicates)->toHaveCount(2)
+        ->and($duplicates->pluck('status')->unique()->all())->toBe([RequisitionStatusEnum::Draft])
+        ->and($duplicates->pluck('created_by_id')->unique()->all())->toBe([$this->recruiter->user->getKey()]);
+});
+
+it('hides the bulk duplicate action for users that are not admins', function (): void {
+    $this->recruiter->user->givePermissionTo('create_job_requisitions');
+
+    Livewire::test(ListJobRequisitions::class)
+        ->assertActionHidden(TestAction::make('duplicate')->table()->bulk());
+});
+
+it('skips trashed requisitions when bulk-duplicating', function (): void {
+    $this->recruiter->user->assignRole(Roles::SuperAdmin->value);
+    $this->recruiter->user->givePermissionTo('create_job_requisitions');
+
+    $trashed = JobRequisition::factory()
+        ->for($this->team)
+        ->for($this->department)
+        ->for($this->recruiter, 'recruiter')
+        ->for($this->recruiter->user, 'createdBy')
+        ->create(['status' => RequisitionStatusEnum::Published]);
+
+    JobPosting::factory()->for($trashed, 'jobRequisition')->create();
+    $trashed->delete();
+
+    Livewire::test(ListJobRequisitions::class)
+        ->filterTable('trashed', true)
+        ->selectTableRecords([$this->jobRequisition->getKey(), $trashed->getKey()])
+        ->callAction(TestAction::make('duplicate')->table()->bulk())
+        ->assertHasNoActionErrors();
+
+    expect(JobRequisition::query()->whereNotIn('id', [$this->jobRequisition->getKey(), $trashed->getKey()])->count())
+        ->toBe(1);
+});

--- a/app-modules/recruitment/src/Requisitions/Actions/DuplicateJobRequisitionAction.php
+++ b/app-modules/recruitment/src/Requisitions/Actions/DuplicateJobRequisitionAction.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Recruitment\Requisitions\Actions;
+
+use He4rt\Recruitment\Requisitions\Enums\RequisitionStatusEnum;
+use He4rt\Recruitment\Requisitions\Models\JobRequisition;
+use He4rt\Recruitment\Stages\Models\Stage;
+use He4rt\Screening\Models\ScreeningQuestion;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+final class DuplicateJobRequisitionAction
+{
+    public function execute(JobRequisition $original, string $createdById): JobRequisition
+    {
+        return DB::transaction(function () use ($original, $createdById): JobRequisition {
+            $original->loadMissing([
+                'post',
+                'items.tags',
+                'screeningQuestions',
+                'stages.screeningQuestions',
+                'stages.interviewers',
+            ]);
+
+            $copySuffix = __('panel-organization::filament.actions.duplicate_job_requisition.title_suffix');
+
+            $duplicate = $original->replicate([
+                'slug',
+                'status',
+                'created_by_id',
+                'approved_at',
+                'published_at',
+                'closed_at',
+                'target_start_at',
+            ]);
+
+            $duplicate->status = RequisitionStatusEnum::Draft;
+            $duplicate->created_by_id = $createdById;
+            $duplicate->slug = Str::slug($original->post->title.' '.$copySuffix);
+            $duplicate->save();
+
+            // The JobRequisitionObserver creates the default pipeline stages on
+            // `created`. Drop them so we can mirror the original stages instead.
+            $duplicate->stages()->forceDelete();
+
+            $post = $original->post->replicate(['job_requisition_id', 'slug']);
+            $post->job_requisition_id = $duplicate->getKey();
+            $post->slug = $duplicate->slug;
+            $post->title = $original->post->title.' '.$copySuffix;
+            $post->save();
+
+            foreach ($original->items as $item) {
+                $clonedItem = $item->replicate(['job_requisition_id']);
+                $clonedItem->job_requisition_id = $duplicate->getKey();
+                $clonedItem->save();
+
+                if ($item->tags->isNotEmpty()) {
+                    $clonedItem->syncTags($item->tags);
+                }
+            }
+
+            foreach ($original->screeningQuestions as $question) {
+                $duplicate->screeningQuestions()->save(
+                    $question->replicate(['screenable_id', 'screenable_type'])
+                );
+            }
+
+            $original->stages->each(function (Stage $stage) use ($duplicate): void {
+                $clonedStage = $stage->replicate(['job_requisition_id']);
+                $duplicate->stages()->save($clonedStage);
+
+                $stage->screeningQuestions->each(function (ScreeningQuestion $question) use ($clonedStage): void {
+                    $clonedStage->screeningQuestions()->save(
+                        $question->replicate(['screenable_id', 'screenable_type'])
+                    );
+                });
+
+                $interviewerIds = $stage->interviewers->pluck('id')->all();
+
+                if ($interviewerIds !== []) {
+                    $clonedStage->interviewers()->attach($interviewerIds);
+                }
+            });
+
+            return $duplicate->refresh();
+        });
+    }
+}

--- a/app-modules/recruitment/tests/Feature/DuplicateJobRequisitionActionTest.php
+++ b/app-modules/recruitment/tests/Feature/DuplicateJobRequisitionActionTest.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Applications\Models\Application;
+use He4rt\Recruitment\Requisitions\Actions\DuplicateJobRequisitionAction;
+use He4rt\Recruitment\Requisitions\Enums\JobRequisitionItemTypeEnum;
+use He4rt\Recruitment\Requisitions\Enums\RequisitionStatusEnum;
+use He4rt\Recruitment\Requisitions\Models\JobPosting;
+use He4rt\Recruitment\Requisitions\Models\JobRequisition;
+use He4rt\Recruitment\Requisitions\Models\JobRequisitionItem;
+use He4rt\Recruitment\Staff\Recruiter\Recruiter;
+use He4rt\Recruitment\Stages\Models\Stage;
+use He4rt\Screening\Models\ScreeningQuestion;
+use He4rt\Users\User;
+
+beforeEach(function (): void {
+    $this->original = JobRequisition::factory()->create([
+        'status' => RequisitionStatusEnum::Published,
+    ]);
+
+    // The observer seeds 8 default stages; replace them with a custom pipeline.
+    $this->original->stages()->forceDelete();
+
+    $this->stages = Stage::factory()
+        ->count(3)
+        ->for($this->original, 'requisition')
+        ->sequence(
+            ['display_order' => 1],
+            ['display_order' => 2],
+            ['display_order' => 3],
+        )
+        ->create(['team_id' => $this->original->team_id]);
+
+    $this->stageWithExtras = $this->stages->first();
+
+    $this->interviewers = Recruiter::factory()->count(2)->create(['team_id' => $this->original->team_id]);
+    $this->stageWithExtras->interviewers()->attach($this->interviewers->pluck('id'));
+
+    ScreeningQuestion::factory()->create([
+        'team_id' => $this->original->team_id,
+        'screenable_id' => $this->stageWithExtras->getKey(),
+        'screenable_type' => $this->stageWithExtras->getMorphClass(),
+        'display_order' => 1,
+    ]);
+
+    $this->post = JobPosting::factory()
+        ->for($this->original, 'jobRequisition')
+        ->create(['title' => 'Senior PHP Engineer']);
+
+    JobRequisitionItem::factory()
+        ->count(3)
+        ->for($this->original, 'jobRequisition')
+        ->create();
+
+    $this->taggedItem = JobRequisitionItem::factory()
+        ->withTags(['php', 'laravel'])
+        ->for($this->original, 'jobRequisition')
+        ->create([
+            'type' => JobRequisitionItemTypeEnum::Responsibility,
+            'content' => 'Tagged responsibility unique content',
+        ]);
+
+    ScreeningQuestion::factory()
+        ->count(2)
+        ->sequence(['display_order' => 1], ['display_order' => 2])
+        ->create([
+            'team_id' => $this->original->team_id,
+            'screenable_id' => $this->original->getKey(),
+            'screenable_type' => $this->original->getMorphClass(),
+        ]);
+
+    $this->actor = User::factory()->create();
+});
+
+it('creates the duplicate as a draft owned by the acting user', function (): void {
+    $duplicate = resolve(DuplicateJobRequisitionAction::class)
+        ->execute($this->original, (string) $this->actor->getKey());
+
+    expect($duplicate->getKey())->not->toBe($this->original->getKey())
+        ->and($duplicate->status)->toBe(RequisitionStatusEnum::Draft)
+        ->and($duplicate->created_by_id)->toBe($this->actor->getKey())
+        ->and($duplicate->approved_at)->toBeNull()
+        ->and($duplicate->published_at)->toBeNull()
+        ->and($duplicate->closed_at)->toBeNull()
+        ->and($duplicate->target_start_at)->toBeNull();
+});
+
+it('generates a new unique slug following the team pattern', function (): void {
+    $originalSlug = $this->original->slug;
+
+    $duplicate = resolve(DuplicateJobRequisitionAction::class)
+        ->execute($this->original, (string) $this->actor->getKey());
+
+    expect($duplicate->slug)->not->toBe($originalSlug)
+        ->and($duplicate->slug)->toMatch('/-'.preg_quote((string) $this->original->team->slug, '/').'-[a-z0-9]{5}$/');
+});
+
+it('produces distinct slugs when the same requisition is duplicated twice', function (): void {
+    $action = resolve(DuplicateJobRequisitionAction::class);
+
+    $first = $action->execute($this->original, (string) $this->actor->getKey());
+    $second = $action->execute($this->original, (string) $this->actor->getKey());
+
+    expect($first->getKey())->not->toBe($second->getKey())
+        ->and($first->slug)->not->toBe($second->slug)
+        ->and(JobRequisition::query()->whereIn('id', [$first->getKey(), $second->getKey()])->count())->toBe(2);
+});
+
+it('copies the job posting with the copy suffix and matching slug', function (): void {
+    $suffix = __('panel-organization::filament.actions.duplicate_job_requisition.title_suffix');
+
+    $duplicate = resolve(DuplicateJobRequisitionAction::class)
+        ->execute($this->original, (string) $this->actor->getKey());
+
+    expect($duplicate->post)->not->toBeNull()
+        ->and($duplicate->post->title)->toBe('Senior PHP Engineer '.$suffix)
+        ->and($duplicate->post->slug)->toBe($duplicate->slug)
+        ->and($duplicate->post->getKey())->not->toBe($this->post->getKey());
+});
+
+it('copies requisition items together with their tags', function (): void {
+    $duplicate = resolve(DuplicateJobRequisitionAction::class)
+        ->execute($this->original, (string) $this->actor->getKey());
+
+    $clonedTaggedItem = $duplicate->items->firstWhere('content', 'Tagged responsibility unique content');
+
+    expect($duplicate->items)->toHaveCount(4)
+        ->and($clonedTaggedItem)->not->toBeNull()
+        ->and($clonedTaggedItem->getKey())->not->toBe($this->taggedItem->getKey())
+        ->and($clonedTaggedItem->tags->pluck('name'))->toHaveCount(2);
+});
+
+it('copies requisition-level screening questions', function (): void {
+    $duplicate = resolve(DuplicateJobRequisitionAction::class)
+        ->execute($this->original, (string) $this->actor->getKey());
+
+    expect($duplicate->screeningQuestions)->toHaveCount(2)
+        ->and($duplicate->screeningQuestions->pluck('id'))
+        ->not->toContain(...$this->original->screeningQuestions->pluck('id')->all());
+});
+
+it('mirrors the original pipeline stages instead of the default ones', function (): void {
+    $duplicate = resolve(DuplicateJobRequisitionAction::class)
+        ->execute($this->original, (string) $this->actor->getKey());
+
+    $clonedStageWithExtras = $duplicate->stages->firstWhere('display_order', 1);
+
+    expect($duplicate->stages)->toHaveCount(3)
+        ->and($duplicate->stages->pluck('display_order')->sort()->values()->all())->toBe([1, 2, 3])
+        ->and($clonedStageWithExtras->screeningQuestions)->toHaveCount(1)
+        ->and($clonedStageWithExtras->interviewers->pluck('id')->sort()->values()->all())
+        ->toBe($this->interviewers->pluck('id')->sort()->values()->all());
+});
+
+it('does not copy applications', function (): void {
+    Application::factory()->for($this->original, 'requisition')->create();
+
+    $applicationCountBefore = Application::query()->count();
+
+    $duplicate = resolve(DuplicateJobRequisitionAction::class)
+        ->execute($this->original, (string) $this->actor->getKey());
+
+    expect($duplicate->applications()->count())->toBe(0)
+        ->and(Application::query()->count())->toBe($applicationCountBefore);
+});
+
+it('leaves the original requisition untouched', function (): void {
+    $originalSlug = $this->original->slug;
+
+    resolve(DuplicateJobRequisitionAction::class)
+        ->execute($this->original, (string) $this->actor->getKey());
+
+    $fresh = $this->original->fresh();
+
+    expect($fresh->status)->toBe(RequisitionStatusEnum::Published)
+        ->and($fresh->slug)->toBe($originalSlug)
+        ->and($fresh->stages()->count())->toBe(3)
+        ->and($fresh->items()->count())->toBe(4);
+});


### PR DESCRIPTION
## Resumo

Adiciona a funcionalidade **Duplicar Vaga** no painel de organização. Permite ao recrutador clonar uma `JobRequisition` existente com toda a sua estrutura, evitando recriar vagas quase idênticas do zero.

Ao duplicar:
- A nova vaga **replica a estrutura** da original: anúncio (`JobPosting`), itens/requisitos (com tags Spatie), faixa salarial, etapas customizadas do pipeline (incluindo perguntas de triagem por etapa e entrevistadores) e perguntas de triagem em nível de requisição;
- **Dados de runtime NÃO são copiados**: candidaturas, respostas de triagem, comentários e avaliações;
- A nova vaga **nasce como rascunho** (`RequisitionStatusEnum::Draft`), independentemente do status da original, com `approved_at` / `published_at` / `closed_at` / `target_start_at` zerados e `created_by_id` = usuário atual;
- O `slug` é regerado (o `JobRequisitionObserver` aplica o sufixo `-{team-slug}-{5-aleatórios}`, garantindo unicidade mesmo ao duplicar a mesma vaga várias vezes);
- As 8 etapas padrão criadas pelo observer são removidas dentro da transação antes de clonar as etapas reais da original.

## O que foi feito

**Domain layer (`recruitment`)**
- `DuplicateJobRequisitionAction` — orquestra toda a clonagem numa única `DB::transaction` usando `Model::replicate()` (padrão Prototype).

**Filament (`panel-organization`)**
- `DuplicateJobRequisitionAction` (row action) — autoriza via `->authorize('create')`, oculta para registros na lixeira, exige confirmação, executa a action de domínio, notifica e redireciona para a edição do novo rascunho;
- `DuplicateJobRequisitionBulkAction` (bulk action) — duplica os registros selecionados, ignorando os que estão na lixeira; restrita a Admin/SuperAdmin;
- Integração: action adicionada ao `ActionGroup` da linha em `JobRequisitionsTable`, ao `BulkActionGroup` do toolbar, e aos headers das páginas `EditJobRequisition` e `ViewJobRequisition`;
- Traduções `en` e `pt_BR` para labels, modais e notificações (incluindo as variantes bulk).

## Plano de testes

- [x] `app-modules/recruitment/tests/Feature/DuplicateJobRequisitionActionTest.php` — status Draft, slug único, clone do anúncio com sufixo, itens + tags, perguntas de triagem, etapas + screening + entrevistadores espelhados (não as 8 padrão), nenhuma candidatura copiada, original intocada, slugs distintos ao duplicar 2x
- [x] `app-modules/panel-organization/tests/Feature/JobRequisition/DuplicateJobRequisitionTest.php` — duplicar pela tabela + redirect, duplicar pelo header da página de edição, action oculta sem permissão `create_job_requisitions`, action oculta para vagas na lixeira, nenhuma candidatura copiada, bulk duplica N vagas, bulk oculto para não-admins, bulk ignora vagas na lixeira
- [x] `php artisan test --compact --filter=DuplicateJobRequisition` → 17/17 passando
- [x] Suíte completa verde · PHPStan limpo · Pint limpo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to duplicate individual job requisitions from the edit and view pages
  * Added bulk duplicate action to duplicate multiple selected job requisitions at once
  * Duplicated requisitions are created in Draft status and associated with the current user
  * Duplicate action is unavailable for users without create permissions and for trashed requisitions

* **Localization**
  * Added English and Portuguese translations for the duplicate action and related UI text

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/3pontos-tech/recruit-party-quest/pull/154)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->