### PR TITLE
feat(panel-organization): navegação entre candidaturas na ViewApplication

### DIFF
--- a/app-modules/panel-organization/lang/en/view.php
+++ b/app-modules/panel-organization/lang/en/view.php
@@ -3,6 +3,13 @@
 declare(strict_types=1);
 
 return [
+    'navigation' => [
+        'aria_label' => 'Application navigation',
+        'previous' => 'Previous',
+        'next' => 'Next',
+        'of' => 'of',
+        'jump_to' => 'Jump to',
+    ],
     'candidate_header' => [
         'position' => 'Position',
         'department' => 'Department',

--- a/app-modules/panel-organization/lang/pt_BR/view.php
+++ b/app-modules/panel-organization/lang/pt_BR/view.php
@@ -3,6 +3,13 @@
 declare(strict_types=1);
 
 return [
+    'navigation' => [
+        'aria_label' => 'Navegação entre candidaturas',
+        'previous' => 'Anterior',
+        'next' => 'Próxima',
+        'of' => 'de',
+        'jump_to' => 'Ir para',
+    ],
     'candidate_header' => [
         'position' => 'Cargo',
         'department' => 'Departamento',

--- a/app-modules/panel-organization/resources/views/components/applications/navigation-bar.blade.php
+++ b/app-modules/panel-organization/resources/views/components/applications/navigation-bar.blade.php
@@ -1,0 +1,131 @@
+@php
+    use Filament\Support\Icons\Heroicon;
+    use He4rt\Applications\Models\Application;
+    use He4rt\Organization\Filament\Resources\Recruitment\Applications\ApplicationResource;
+    use He4rt\Organization\Filament\Resources\Recruitment\Applications\Support\ApplicationNavigationContext;
+
+    /** @var ApplicationNavigationContext $context */
+    /** @var Application $record */
+@endphp
+
+<div
+    class="flex items-center justify-between gap-4 rounded-lg border border-gray-200 bg-white px-4 py-2.5 shadow-sm dark:border-gray-700 dark:bg-gray-900"
+    role="navigation"
+    aria-label="{{ __('panel-organization::view.navigation.aria_label') }}"
+>
+    {{-- Previous --}}
+    @if ($context->previous)
+        <a
+            href="{{ ApplicationResource::getUrl('view', ['record' => $context->previous]) }}"
+            class="hover:text-primary-600 inline-flex items-center gap-2 text-sm font-medium text-gray-900 transition dark:text-gray-100"
+        >
+            <x-he4rt::icon :icon="Heroicon::ArrowLeft" size="xs" />
+            <span>{{ __('panel-organization::view.navigation.previous') }}</span>
+            <span
+                class="hidden border-l border-gray-200 pl-2 text-xs font-normal text-gray-500 md:inline dark:border-gray-700"
+            >
+                {{ $context->previous->candidate?->user?->name }}
+            </span>
+        </a>
+    @else
+        <button
+            type="button"
+            disabled
+            class="inline-flex cursor-not-allowed items-center gap-2 text-sm font-medium text-gray-400 dark:text-gray-600"
+        >
+            <x-he4rt::icon :icon="Heroicon::ArrowLeft" size="xs" />
+            <span>{{ __('panel-organization::view.navigation.previous') }}</span>
+        </button>
+    @endif
+
+    {{-- Counter + Dropdown --}}
+    <div class="flex items-center gap-3">
+        <span class="text-xs tracking-wider text-gray-500 uppercase tabular-nums dark:text-gray-400">
+            <span class="text-sm font-semibold text-gray-900 dark:text-gray-100">{{ $context->position }}</span>
+            {{ __('panel-organization::view.navigation.of') }}
+            <span class="text-sm font-semibold text-gray-900 dark:text-gray-100">{{ $context->total }}</span>
+        </span>
+
+        <div x-data="{ open: false }" class="relative hidden md:block">
+            <button
+                type="button"
+                x-on:click="open = !open"
+                x-on:click.outside="open = false"
+                class="inline-flex items-center gap-2 rounded-full border border-gray-200 bg-gray-50 px-3 py-1 text-sm font-medium text-gray-900 transition hover:border-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+            >
+                <span class="bg-primary-500 h-1.5 w-1.5 rounded-full"></span>
+                <span>{{ $record->candidate?->user?->name }}</span>
+                <x-he4rt::icon :icon="Heroicon::ChevronDown" size="xs" class="text-gray-500" />
+            </button>
+
+            <ul
+                x-show="open"
+                x-cloak
+                x-transition.opacity
+                class="absolute right-0 z-20 mt-2 max-h-96 w-96 overflow-y-auto rounded-lg border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-900"
+            >
+                @foreach ($context->allActive as $candidatura)
+                    @php
+                        $isCurrent = $candidatura->id === $record->id;
+                        $stageName = $candidatura->currentStage?->name;
+                    @endphp
+
+                    <li>
+                        <a
+                            href="{{ ApplicationResource::getUrl('view', ['record' => $candidatura]) }}"
+                            @class([
+                                'flex items-center justify-between gap-3 px-4 py-2.5 text-sm transition',
+                                'bg-gray-900 text-white dark:bg-gray-100 dark:text-gray-900' => $isCurrent,
+                                'text-gray-900 hover:bg-gray-50 dark:text-gray-100 dark:hover:bg-gray-800' => ! $isCurrent,
+                            ])
+                        >
+                            <span class="flex min-w-0 items-center gap-2">
+                                @if ($isCurrent)
+                                    <x-he4rt::icon :icon="Heroicon::Play" size="xs" class="shrink-0" />
+                                @endif
+
+                                <span class="truncate font-medium">{{ $candidatura->candidate?->user?->name }}</span>
+                            </span>
+                            @if ($stageName)
+                                <span
+                                    @class([
+                                        'shrink-0 rounded-full border px-2 py-0.5 text-xs whitespace-nowrap',
+                                        'border-white/25 bg-white/10' => $isCurrent,
+                                        'border-gray-200 bg-gray-50 text-gray-600 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-400' => ! $isCurrent,
+                                    ])
+                                >
+                                    {{ $stageName }}
+                                </span>
+                            @endif
+                        </a>
+                    </li>
+                @endforeach
+            </ul>
+        </div>
+    </div>
+
+    {{-- Next --}}
+    @if ($context->next)
+        <a
+            href="{{ ApplicationResource::getUrl('view', ['record' => $context->next]) }}"
+            class="hover:text-primary-600 inline-flex items-center gap-2 text-sm font-medium text-gray-900 transition dark:text-gray-100"
+        >
+            <span
+                class="hidden border-r border-gray-200 pr-2 text-xs font-normal text-gray-500 md:inline dark:border-gray-700"
+            >
+                {{ $context->next->candidate?->user?->name }}
+            </span>
+            <span>{{ __('panel-organization::view.navigation.next') }}</span>
+            <x-he4rt::icon :icon="Heroicon::ArrowRight" size="xs" />
+        </a>
+    @else
+        <button
+            type="button"
+            disabled
+            class="inline-flex cursor-not-allowed items-center gap-2 text-sm font-medium text-gray-400 dark:text-gray-600"
+        >
+            <span>{{ __('panel-organization::view.navigation.next') }}</span>
+            <x-he4rt::icon :icon="Heroicon::ArrowRight" size="xs" />
+        </button>
+    @endif
+</div>

--- a/app-modules/panel-organization/src/Filament/Resources/Recruitment/Applications/Schemas/ApplicationInfolist.php
+++ b/app-modules/panel-organization/src/Filament/Resources/Recruitment/Applications/Schemas/ApplicationInfolist.php
@@ -16,6 +16,7 @@ use Filament\Support\Enums\Width;
 use Filament\Support\Icons\Heroicon;
 use He4rt\Applications\Models\Application;
 use He4rt\Organization\Filament\Resources\Recruitment\Applications\Actions\RejectApplicationAction;
+use He4rt\Organization\Filament\Resources\Recruitment\Applications\Support\ApplicationNavigationContext;
 use He4rt\Organization\Filament\Resources\Recruitment\JobRequisitions\Pages\Kanban\Actions\StateTransitionAction;
 use He4rt\Permissions\Roles;
 use He4rt\Users\User;
@@ -30,6 +31,16 @@ class ApplicationInfolist
         return $schema
             ->columns(4)
             ->components([
+                ViewEntry::make('navigation_bar')
+                    ->view('panel-organization::components.applications.navigation-bar')
+                    ->viewData(fn (Application $record): array => [
+                        'context' => once(fn () => ApplicationNavigationContext::forApplication($record)),
+                    ])
+                    ->visible(fn (Application $record): bool => once(
+                        fn () => ApplicationNavigationContext::forApplication($record)
+                    )->shouldRender())
+                    ->columnSpanFull(),
+
                 ViewEntry::make('header')
                     ->view('panel-organization::components.applications.candidate-header')
                     ->columnSpanFull(),

--- a/app-modules/panel-organization/src/Filament/Resources/Recruitment/Applications/Support/ApplicationNavigationContext.php
+++ b/app-modules/panel-organization/src/Filament/Resources/Recruitment/Applications/Support/ApplicationNavigationContext.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Organization\Filament\Resources\Recruitment\Applications\Support;
+
+use He4rt\Applications\Enums\ApplicationStatusEnum;
+use He4rt\Applications\Models\Application;
+use Illuminate\Support\Collection;
+
+final readonly class ApplicationNavigationContext
+{
+    /**
+     * @param  Collection<int, Application>  $allActive
+     */
+    private function __construct(
+        public Application $current,
+        public ?Application $previous,
+        public ?Application $next,
+        public ?int $position,
+        public int $total,
+        public Collection $allActive,
+    ) {}
+
+    public static function forApplication(Application $current): self
+    {
+        /** @var Collection<int, Application> $allActive */
+        $allActive = Application::query()
+            ->where('requisition_id', $current->requisition_id)
+            ->whereNotIn('status', [
+                ApplicationStatusEnum::Rejected,
+                ApplicationStatusEnum::Withdrawn,
+            ])
+            ->with(['candidate.user', 'currentStage'])
+            ->orderBy('created_at')
+            ->orderBy('id')
+            ->get();
+
+        $index = $allActive->search(fn (Application $app): bool => $app->id === $current->id);
+
+        if ($index === false) {
+            return new self(
+                current: $current,
+                previous: null,
+                next: null,
+                position: null,
+                total: $allActive->count(),
+                allActive: $allActive,
+            );
+        }
+
+        return new self(
+            current: $current,
+            previous: $index > 0 ? $allActive->get($index - 1) : null,
+            next: $index < $allActive->count() - 1 ? $allActive->get($index + 1) : null,
+            position: $index + 1,
+            total: $allActive->count(),
+            allActive: $allActive,
+        );
+    }
+
+    public function shouldRender(): bool
+    {
+        return $this->position !== null && $this->total > 1;
+    }
+}

--- a/app-modules/panel-organization/tests/Feature/Filament/Application/ApplicationNavigationBarTest.php
+++ b/app-modules/panel-organization/tests/Feature/Filament/Application/ApplicationNavigationBarTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\FilamentPanel;
+use He4rt\Applications\Enums\ApplicationStatusEnum;
+use He4rt\Applications\Models\Application;
+use He4rt\Candidates\Models\Candidate;
+use He4rt\Organization\Filament\Resources\Recruitment\Applications\ApplicationResource;
+use He4rt\Organization\Filament\Resources\Recruitment\Applications\Pages\ViewApplication;
+use He4rt\Permissions\Roles;
+use He4rt\Recruitment\Requisitions\Models\JobPosting;
+use He4rt\Recruitment\Requisitions\Models\JobRequisition;
+use He4rt\Recruitment\Staff\Recruiter\Recruiter;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    $this->requisition = JobRequisition::factory()->create();
+    JobPosting::factory()->for($this->requisition, 'jobRequisition')->createOne();
+    $this->team = $this->requisition->team;
+
+    $this->recruiter = Recruiter::factory()->for($this->team, 'team')->create();
+    $this->recruiter->user->assignRole(Roles::SuperAdmin->value);
+    actingAs($this->recruiter->user);
+
+    filament()->setCurrentPanel(FilamentPanel::Organization->value);
+    filament()->setTenant($this->team);
+});
+
+function makeAppInRequisition(JobRequisition $requisition, ApplicationStatusEnum $status, string $createdAt): Application
+{
+    $candidate = Candidate::factory()->create();
+
+    return Application::factory()
+        ->for($requisition, 'requisition')
+        ->for($candidate, 'candidate')
+        ->state([
+            'status' => $status,
+            'created_at' => $createdAt,
+            'updated_at' => $createdAt,
+        ])
+        ->create();
+}
+
+it('renders the navigation bar when the requisition has multiple active applications', function (): void {
+    $apps = collect([
+        '2026-05-01 10:00:00',
+        '2026-05-02 10:00:00',
+        '2026-05-03 10:00:00',
+        '2026-05-04 10:00:00',
+        '2026-05-05 10:00:00',
+    ])->map(fn (string $ts) => makeAppInRequisition(
+        $this->requisition,
+        ApplicationStatusEnum::InReview,
+        $ts,
+    ));
+
+    livewire(ViewApplication::class, ['record' => $apps[2]->getKey()])
+        ->assertOk()
+        ->assertSee(__('panel-organization::view.navigation.previous'))
+        ->assertSee(__('panel-organization::view.navigation.next'))
+        ->assertSee('3')
+        ->assertSee('5')
+        ->assertSee(ApplicationResource::getUrl('view', ['record' => $apps[1]]), escape: false)
+        ->assertSee(ApplicationResource::getUrl('view', ['record' => $apps[3]]), escape: false);
+});
+
+it('hides the navigation bar when the requisition has only one active application', function (): void {
+    $only = makeAppInRequisition($this->requisition, ApplicationStatusEnum::InReview, '2026-05-01 10:00:00');
+
+    livewire(ViewApplication::class, ['record' => $only->getKey()])
+        ->assertOk()
+        ->assertDontSee(__('panel-organization::view.navigation.aria_label'));
+});
+
+it('hides the navigation bar when the current application is rejected', function (): void {
+    foreach (range(1, 10) as $i) {
+        makeAppInRequisition($this->requisition, ApplicationStatusEnum::InReview, sprintf('2026-05-%02d 10:00:00', $i));
+    }
+
+    $rejected = makeAppInRequisition($this->requisition, ApplicationStatusEnum::Rejected, '2026-05-11 10:00:00');
+
+    livewire(ViewApplication::class, ['record' => $rejected->getKey()])
+        ->assertOk()
+        ->assertDontSee(__('panel-organization::view.navigation.aria_label'));
+});
+
+it('hides the navigation bar when the current application is withdrawn', function (): void {
+    foreach (range(1, 3) as $i) {
+        makeAppInRequisition($this->requisition, ApplicationStatusEnum::InReview, sprintf('2026-05-%02d 10:00:00', $i));
+    }
+
+    $withdrawn = makeAppInRequisition($this->requisition, ApplicationStatusEnum::Withdrawn, '2026-05-11 10:00:00');
+
+    livewire(ViewApplication::class, ['record' => $withdrawn->getKey()])
+        ->assertOk()
+        ->assertDontSee(__('panel-organization::view.navigation.aria_label'));
+});
+
+it('disables the previous button on the first application', function (): void {
+    $apps = collect([
+        '2026-05-01 10:00:00',
+        '2026-05-02 10:00:00',
+        '2026-05-03 10:00:00',
+    ])->map(fn (string $ts) => makeAppInRequisition(
+        $this->requisition,
+        ApplicationStatusEnum::InReview,
+        $ts,
+    ));
+
+    livewire(ViewApplication::class, ['record' => $apps[0]->getKey()])
+        ->assertOk()
+        ->assertSeeHtmlInOrder([
+            '<button',
+            'disabled',
+            __('panel-organization::view.navigation.previous'),
+        ]);
+});
+
+it('disables the next button on the last application', function (): void {
+    $apps = collect([
+        '2026-05-01 10:00:00',
+        '2026-05-02 10:00:00',
+        '2026-05-03 10:00:00',
+    ])->map(fn (string $ts) => makeAppInRequisition(
+        $this->requisition,
+        ApplicationStatusEnum::InReview,
+        $ts,
+    ));
+
+    livewire(ViewApplication::class, ['record' => $apps[2]->getKey()])
+        ->assertOk()
+        ->assertSeeHtmlInOrder([
+            '<button',
+            'disabled',
+            __('panel-organization::view.navigation.next'),
+        ]);
+});
+
+it('lists all active applications in the dropdown excluding rejected/withdrawn', function (): void {
+    $a = makeAppInRequisition($this->requisition, ApplicationStatusEnum::InReview, '2026-05-01 10:00:00');
+    $b = makeAppInRequisition($this->requisition, ApplicationStatusEnum::Rejected, '2026-05-02 10:00:00');
+    $c = makeAppInRequisition($this->requisition, ApplicationStatusEnum::InReview, '2026-05-03 10:00:00');
+
+    livewire(ViewApplication::class, ['record' => $a->getKey()])
+        ->assertOk()
+        ->assertSee($a->candidate->user->name)
+        ->assertSee($c->candidate->user->name)
+        ->assertDontSee($b->candidate->user->name);
+});

--- a/app-modules/panel-organization/tests/Feature/Support/ApplicationNavigationContextTest.php
+++ b/app-modules/panel-organization/tests/Feature/Support/ApplicationNavigationContextTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Applications\Enums\ApplicationStatusEnum;
+use He4rt\Applications\Models\Application;
+use He4rt\Organization\Filament\Resources\Recruitment\Applications\Support\ApplicationNavigationContext;
+use He4rt\Recruitment\Requisitions\Models\JobRequisition;
+
+beforeEach(function (): void {
+    $this->requisition = JobRequisition::factory()->create();
+});
+
+function makeApplication(JobRequisition $requisition, ApplicationStatusEnum $status, string $createdAt): Application
+{
+    return Application::factory()
+        ->for($requisition, 'requisition')
+        ->state([
+            'status' => $status,
+            'created_at' => $createdAt,
+            'updated_at' => $createdAt,
+        ])
+        ->create();
+}
+
+it('computes position and total within the active set of the requisition', function (): void {
+    $apps = collect([
+        '2026-05-01 10:00:00',
+        '2026-05-02 10:00:00',
+        '2026-05-03 10:00:00',
+        '2026-05-04 10:00:00',
+        '2026-05-05 10:00:00',
+    ])->map(fn (string $ts) => makeApplication($this->requisition, ApplicationStatusEnum::InReview, $ts));
+
+    $context = ApplicationNavigationContext::forApplication($apps[2]);
+
+    expect($context->position)->toBe(3);
+    expect($context->total)->toBe(5);
+    expect($context->previous?->id)->toBe($apps[1]->id);
+    expect($context->next?->id)->toBe($apps[3]->id);
+    expect($context->shouldRender())->toBeTrue();
+});
+
+it('excludes rejected and withdrawn from the active set', function (): void {
+    $active1 = makeApplication($this->requisition, ApplicationStatusEnum::InReview, '2026-05-01 10:00:00');
+    makeApplication($this->requisition, ApplicationStatusEnum::Rejected, '2026-05-02 10:00:00');
+    makeApplication($this->requisition, ApplicationStatusEnum::Withdrawn, '2026-05-03 10:00:00');
+    $active2 = makeApplication($this->requisition, ApplicationStatusEnum::New, '2026-05-04 10:00:00');
+
+    $context = ApplicationNavigationContext::forApplication($active1);
+
+    expect($context->total)->toBe(2);
+    expect($context->position)->toBe(1);
+    expect($context->next?->id)->toBe($active2->id);
+});
+
+it('returns shouldRender false when current record is outside the active set', function (): void {
+    makeApplication($this->requisition, ApplicationStatusEnum::InReview, '2026-05-01 10:00:00');
+    $rejected = makeApplication($this->requisition, ApplicationStatusEnum::Rejected, '2026-05-02 10:00:00');
+    makeApplication($this->requisition, ApplicationStatusEnum::InReview, '2026-05-03 10:00:00');
+
+    $context = ApplicationNavigationContext::forApplication($rejected);
+
+    expect($context->position)->toBeNull();
+    expect($context->total)->toBe(2);
+    expect($context->shouldRender())->toBeFalse();
+});
+
+it('returns shouldRender false when only one active candidature exists', function (): void {
+    $only = makeApplication($this->requisition, ApplicationStatusEnum::InReview, '2026-05-01 10:00:00');
+
+    $context = ApplicationNavigationContext::forApplication($only);
+
+    expect($context->position)->toBe(1);
+    expect($context->total)->toBe(1);
+    expect($context->shouldRender())->toBeFalse();
+    expect($context->previous)->toBeNull();
+    expect($context->next)->toBeNull();
+});
+
+it('disables previous on the first record and next on the last', function (): void {
+    $first = makeApplication($this->requisition, ApplicationStatusEnum::InReview, '2026-05-01 10:00:00');
+    makeApplication($this->requisition, ApplicationStatusEnum::InReview, '2026-05-02 10:00:00');
+    $last = makeApplication($this->requisition, ApplicationStatusEnum::InReview, '2026-05-03 10:00:00');
+
+    $firstContext = ApplicationNavigationContext::forApplication($first);
+    expect($firstContext->previous)->toBeNull();
+    expect($firstContext->next)->not->toBeNull();
+
+    $lastContext = ApplicationNavigationContext::forApplication($last);
+    expect($lastContext->previous)->not->toBeNull();
+    expect($lastContext->next)->toBeNull();
+});
+
+it('breaks created_at ties using id', function (): void {
+    $sharedTimestamp = '2026-05-01 10:00:00';
+    $a = makeApplication($this->requisition, ApplicationStatusEnum::InReview, $sharedTimestamp);
+    $b = makeApplication($this->requisition, ApplicationStatusEnum::InReview, $sharedTimestamp);
+
+    [$lower, $higher] = $a->id < $b->id ? [$a, $b] : [$b, $a];
+
+    $context = ApplicationNavigationContext::forApplication($lower);
+    expect($context->next?->id)->toBe($higher->id);
+});
+
+it('isolates the navigable set per requisition', function (): void {
+    $otherRequisition = JobRequisition::factory()->create();
+    $inV1 = makeApplication($this->requisition, ApplicationStatusEnum::InReview, '2026-05-01 10:00:00');
+    makeApplication($otherRequisition, ApplicationStatusEnum::InReview, '2026-05-02 10:00:00');
+    makeApplication($otherRequisition, ApplicationStatusEnum::InReview, '2026-05-03 10:00:00');
+
+    $context = ApplicationNavigationContext::forApplication($inV1);
+
+    expect($context->total)->toBe(1);
+    expect($context->allActive)->toHaveCount(1);
+});


### PR DESCRIPTION
## O que essa branch faz?

<img width="1282" height="500" alt="new-feature" src="https://github.com/user-attachments/assets/eb10389f-f0d9-444f-90c7-0443cd366c0f" />

Permite que recrutadores naveguem entre as candidaturas de uma mesma vaga **diretamente dentro da página de visualização de um candidato**, sem precisar voltar à listagem geral toda vez.

Uma barra fina aparece no topo da view com:

- **← Anterior** — vai pra candidatura imediatamente antes (também mostra o nome dela em telas maiores)
- **Contador "X de Y"** — sua posição na fila de candidaturas ativas da vaga
- **Dropdown com o candidato atual** — abre uma lista com todos os candidatos ativos da vaga, mostrando a etapa em que cada um está. Clicar pula direto para qualquer um
- **Próxima →** — vai pra próxima candidatura

## Por que isso importa?

### 🎯 Triagem em sequência

Hoje, pra revisar 10 candidatos da vaga "Frontend Developer", o recrutador faz:

```
Listagem → clica em João → analisa → volta pra listagem
Listagem → clica em Maria → analisa → volta pra listagem
... (repete 10x)
```

Com essa branch:

```
Entra no João → analisa → "Próxima" → cai na Maria
Continua a Maria → "Próxima" → Carlos → e assim por diante
```

Menos cliques, menos perda de contexto, mais foco.

### 🔎 Pular pra alguém específico

No meio da revisão, o recrutador lembra: "preciso comparar com a Ana antes de decidir sobre o João". Em vez de voltar à lista e procurar, ele abre o dropdown no topo da view, vê os 14 candidatos ativos com a etapa de cada um, e clica direto na Ana.

### 🚫 Após rejeitar, a barra desaparece

Quando o recrutador rejeita uma candidatura (via "Quick Actions" na sidebar), aquela candidatura sai da fila ativa. A barra de navegação então **some** da view dela — sinalizando claramente que esse candidato não faz mais parte da triagem em andamento. Pra continuar revisando os ativos, basta voltar à listagem.

O mesmo vale pra candidaturas retiradas (withdrawn) — ou se alguém abrir o link direto de uma candidatura já rejeitada por outro recrutador no passado.

### ↩️ Voltar com naturalidade

Se o recrutador navegou Maria → Carlos → Lúcia e quer voltar pra Carlos, basta o **botão "Voltar" do navegador** — funciona como em qualquer site. O histórico do browser é preservado a cada navegação.

## O que **não** muda

- **Layout da view continua igual** — cabeçalho do candidato, abas (Overview, Experience, Screening, Comments, Feedbacks), sidebar com Pipeline Progress e Quick Actions
- **Quem rejeita, contrata, ou avança etapa** continua usando as mesmas Quick Actions de sempre
- **A listagem geral de candidaturas** não foi alterada — filtros, agrupamento por vaga, busca, tudo igual
- **Permissões** seguem as mesmas — quem não tem acesso à candidatura nem chega na view

## Regras da fila navegável

| Regra | Detalhe |
|---|---|
| Escopo | Mesma vaga (não cruza requisições) |
| Ordem | Por data de candidatura (mais antiga primeiro) |
| Inclusão | Apenas candidaturas ativas |
| Exclusão | `rejected` e `withdrawn` ficam de fora |
| Barra some quando | A vaga tem só 1 ativa **OU** a candidatura atual está rejeitada/retirada |
| Mobile | Em telas pequenas (<768px) o dropdown some; prev/próxima e contador continuam |

## Cobertura de testes

**14 testes** cobrindo o comportamento:

- 7 testes do cálculo de "quem é o anterior", "quem é o próximo", "quantos no total" — incluindo casos de borda (primeira candidatura, última, vaga com só uma, registro fora da fila ativa, empate de data) e isolamento entre vagas diferentes
- 7 testes da renderização real na view — barra aparece/some corretamente, links apontam pros candidatos certos, botões desabilitam nas extremidades

A suíte completa do módulo `panel-organization` (126 testes) continua verde — zero regressão em funcionalidades existentes.
