### PR TITLE
feat/seed candidate skills catalog

### DIFF
--- a/app-modules/candidates/database/migrations/2026_05_26_120000_seed_candidate_skills_catalog.php
+++ b/app-modules/candidates/database/migrations/2026_05_26_120000_seed_candidate_skills_catalog.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+/**
+ * Seeds the canonical catalog of candidate skills (hard skills, soft skills, languages).
+ *
+ * Previously this list lived only in DevelopmentSeeder, which is gated behind
+ * `! app()->isProduction()`. As a result, production had an empty
+ * `candidate_skills` table and the profile's skill <select> rendered with no
+ * options. This migration ships the catalog as schema, so any environment
+ * (prod, staging, fresh dev) has a baseline list available.
+ *
+ * Idempotent: skips any name that already exists as a live (non-soft-deleted)
+ * row, so it's safe to run on environments where DevelopmentSeeder has already
+ * populated the table.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $now = Date::now();
+
+        foreach ($this->catalog() as $category => $names) {
+            foreach ($names as $name) {
+                $exists = DB::table('candidate_skills')
+                    ->where('name', $name)
+                    ->whereNull('deleted_at')
+                    ->exists();
+
+                if ($exists) {
+                    continue;
+                }
+
+                DB::table('candidate_skills')->insert([
+                    'id' => (string) Str::uuid(),
+                    'name' => $name,
+                    'category' => $category,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ]);
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        $names = collect($this->catalog())->flatten()->all();
+
+        // Only remove catalog rows that no candidate is currently referencing.
+        // This prevents rollback from orphaning real candidate skill assignments.
+        $referencedSkillIds = DB::table('candidate_known_skills')
+            ->distinct()
+            ->pluck('skill_id')
+            ->all();
+
+        DB::table('candidate_skills')
+            ->whereIn('name', $names)
+            ->whereNotIn('id', $referencedSkillIds)
+            ->delete();
+    }
+
+    /**
+     * @return array<string, list<string>>
+     */
+    private function catalog(): array
+    {
+        return [
+            'hard_skill' => [
+                'PHP', 'Laravel', 'Symfony', 'Node.js', 'Python', 'Java', 'C#', '.NET',
+                'JavaScript', 'TypeScript', 'React', 'Vue.js', 'Angular', 'HTML', 'CSS', 'Tailwind',
+                'Flutter', 'React Native', 'Swift', 'Kotlin', 'Dart',
+                'Docker', 'AWS', 'Azure', 'Kubernetes', 'CI/CD', 'Jenkins', 'GitLab',
+                'MySQL', 'PostgreSQL', 'MongoDB', 'Redis', 'ElasticSearch',
+                'Git', 'REST API', 'GraphQL',
+            ],
+            'soft_skill' => [
+                'Leadership', 'Communication', 'Teamwork', 'Problem Solving',
+                'Critical Thinking', 'Time Management', 'Adaptability',
+                'Project Management', 'Agile', 'Scrum',
+            ],
+            'language' => [
+                'English', 'Portuguese', 'Spanish', 'French', 'German',
+            ],
+        ];
+    }
+};

--- a/database/seeders/DevelopmentSeeder.php
+++ b/database/seeders/DevelopmentSeeder.php
@@ -28,6 +28,7 @@ use He4rt\Users\User;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Collection;
+use RuntimeException;
 
 final class DevelopmentSeeder extends Seeder
 {
@@ -61,7 +62,7 @@ final class DevelopmentSeeder extends Seeder
         $this->adminTeam = $adminData['team'];
         $this->departments = $adminData['departments'];
 
-        $this->skills = $this->createFocusedSkills();
+        $this->skills = $this->loadCatalogSkills();
 
         $candidates = $this->createCandidates(25);
 
@@ -80,57 +81,22 @@ final class DevelopmentSeeder extends Seeder
         $this->command->info('Development Seeder completed.');
     }
 
-    private function createFocusedSkills(): Collection
+    /**
+     * Loads the canonical skill catalog seeded by
+     * `2026_05_26_120000_seed_candidate_skills_catalog` migration.
+     *
+     * The catalog used to be created here, but that meant production (where
+     * DevelopmentSeeder never runs) had no skills. Now the migration is the
+     * single source of truth and this seeder only consumes it.
+     */
+    private function loadCatalogSkills(): Collection
     {
-        $this->command->info('Creating focused skills...');
+        $this->command->info('Loading skill catalog...');
 
-        $skills = collect();
+        $skills = Skill::query()->get();
 
-        $hardSkills = [
-            'PHP', 'Laravel', 'Symfony', 'Node.js', 'Python', 'Java', 'C#', '.NET',
-            'JavaScript', 'TypeScript', 'React', 'Vue.js', 'Angular', 'HTML', 'CSS', 'Tailwind',
-            'Flutter', 'React Native', 'Swift', 'Kotlin', 'Dart',
-            'Docker', 'AWS', 'Azure', 'Kubernetes', 'CI/CD', 'Jenkins', 'GitLab',
-            'MySQL', 'PostgreSQL', 'MongoDB', 'Redis', 'ElasticSearch',
-            'Git', 'REST API', 'GraphQL',
-        ];
-
-        $softSkills = [
-            'Leadership', 'Communication', 'Teamwork', 'Problem Solving',
-            'Critical Thinking', 'Time Management', 'Adaptability',
-            'Project Management', 'Agile', 'Scrum',
-        ];
-
-        $languages = [
-            'English', 'Portuguese', 'Spanish', 'French', 'German',
-        ];
-
-        foreach ($hardSkills as $skillName) {
-            $skill = Skill::factory()->create([
-                'name' => $skillName,
-                'category' => 'hard_skill',
-            ]);
-
-            $skills->push($skill);
-        }
-
-        foreach ($softSkills as $skillName) {
-            $skill = Skill::factory()->create([
-                'name' => $skillName,
-                'category' => 'soft_skill',
-            ]);
-
-            $skills->push($skill);
-        }
-
-        foreach ($languages as $skillName) {
-            $skill = Skill::factory()->create([
-                'name' => $skillName,
-                'category' => 'language',
-            ]);
-
-            $skills->push($skill);
-        }
+        throw_if($skills->isEmpty(), RuntimeException::class, 'Skill catalog is empty. Run `php artisan migrate` before seeding — '
+        .'the catalog is populated by the candidate skills catalog migration.');
 
         return $skills;
     }


### PR DESCRIPTION
## Contexto

Em produção, o seletor de habilidades no perfil do candidato aparece **vazio** — nenhuma opção para escolher. Localmente o problema nunca foi visível porque o ambiente de desenvolvimento já vinha pré-carregado com ~50 habilidades por meio de um script que **nunca roda em produção** por design.

Resultado: candidatos em prod não conseguem cadastrar nenhuma habilidade no perfil.

## O que muda

Essa branch resolve em duas frentes complementares:

1. **Cria o catálogo oficial como parte do banco de dados**, garantindo que qualquer ambiente (produção, staging, sandbox) já nasça com as 51 habilidades disponíveis.
2. **Elimina a duplicação** que existia entre o "catálogo de dev" e a "vida real" — agora há um único lugar onde a lista canônica vive.

A lista é exatamente a mesma que os devs já usavam localmente: nenhum item novo, nenhum removido. O que existia escondido no ambiente de dev passa a existir publicamente em todos os ambientes.

## Catálogo

| Categoria | Quantidade | Exemplos |
|---|---|---|
| Hard skills (técnicas) | 36 | PHP, Laravel, React, Docker, AWS, MySQL, Git |
| Soft skills (comportamentais) | 10 | Liderança, Comunicação, Trabalho em equipe |
| Idiomas | 5 | Inglês, Português, Espanhol, Francês, Alemão |

## Segurança

A migração é **idempotente** — pode rodar mil vezes sem duplicar nada. Se uma habilidade já existe no banco, ela é simplesmente ignorada. Zero risco de subir esse código em qualquer ambiente que já tenha habilidades cadastradas.

## O que não muda

- O seletor de habilidades continua visualmente igual, só passa a ter opções dentro dele
- Habilidades já cadastradas por candidatos ficam intocadas
- Regras de permissão seguem iguais
- O fluxo de onboarding não muda

## Próximos passos sugeridos (fora desta branch)

- Dar a recrutadores/admins uma tela para gerenciar o catálogo (adicionar, marcar como obsoletas, agrupar sinônimos). Hoje o catálogo é fechado — só dev consegue editar.
- Adicionar restrição no banco que impeça habilidades duplicadas pelo mesmo nome (ex: evitar "PHP" e "Php" como entradas separadas).
