### PR TITLE
feat(panel-app): limita resumo das vagas a 2 linhas nos cards

### DIFF
--- a/app-modules/panel-app/resources/views/components/jobs/job-card.blade.php
+++ b/app-modules/panel-app/resources/views/components/jobs/job-card.blade.php
@@ -38,7 +38,7 @@
         </div>
     </x-slot>
 
-    <x-slot:description class="mt-3 leading-relaxed">
+    <x-slot:description class="mt-3 line-clamp-2 leading-relaxed break-words">
         {{ $job->post?->summary }}
     </x-slot>
 
@@ -62,7 +62,7 @@
             variant="ghost"
             class="group-hover:text-text-high transition duration-500"
         >
-            {{ $job->employment_type?->getLabel() ?? $job->work_schedule?->getLabel() ?? __('recruitment::filament.requisition.fields.not_specified') }}
+            {{ $job->employment_type?->getLabel() ?? ($job->work_schedule?->getLabel() ?? __('recruitment::filament.requisition.fields.not_specified')) }}
         </x-he4rt::tag>
         @if ($job->show_salary_to_candidates && ! is_null($job->salary_range_min) && ! is_null($job->salary_range_max))
             <x-he4rt::tag


### PR DESCRIPTION
## O problema

Quando alguém criava uma vaga com um resumo muito longo, o card daquela vaga "esticava" e ficava desalinhado dos outros nas páginas de listagem (`/` e `/vagas`). Isso quebrava o visual do grid e atrapalhava a leitura.

## A solução

Os cards agora mostram **no máximo 2 linhas** do resumo da vaga, com reticências (`...`) quando o texto for maior. O conteúdo completo continua disponível normalmente na página de detalhes da vaga — a mudança é só na aparência do card, nada do que já foi cadastrado é alterado.

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Job card descriptions now display with enhanced text formatting, intelligent word-breaking, and optimized truncation for improved readability and consistent presentation.
  * Employment type labels are resolved with improved fallback logic to ensure accurate job classification information is reliably and clearly displayed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/3pontos-tech/recruit-party-quest/pull/176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
