### PR TITLE
fix: valida dados do onboarding antes de finalizar o cadastro

### DIFF
--- a/app-modules/candidates/tests/Feature/CandidateOnboardingTest.php
+++ b/app-modules/candidates/tests/Feature/CandidateOnboardingTest.php
@@ -97,6 +97,7 @@ it('should be able to onboard', function (): void {
         ->set('data.is_open_to_remote', true)
         ->set('data.experience_level', 'intern')
         ->set('data.employment_type_interests', 'whatever')
+        ->set('data.phone', '+5511987654321')
         ->set('data.confirm_submission', true)
         ->set('data.data_consent_given', true)
         ->call('onResumeAnalyzed', $this->dto)

--- a/app-modules/panel-app/src/Filament/Pages/OnboardingWizard.php
+++ b/app-modules/panel-app/src/Filament/Pages/OnboardingWizard.php
@@ -168,20 +168,15 @@ class OnboardingWizard extends Page
 
     public function handleRegistration(): void
     {
-        $data = $this->data;
-        if (! ($data['data_consent_given'] ?? false)) {
-            Notification::make()
-                ->title(__('panel-app::pages/onboarding.notifications.consent_required.title'))->danger()
-                ->send();
+        $data = $this->content->getState();
 
-            return;
-        }
-
-        $experiences = CandidateWorkExperienceCollection::fromArray($data['work_experiences']);
+        $experiences = CandidateWorkExperienceCollection::fromArray($data['work_experiences'] ?? []);
         resolve(StoreCandidateWorkExperiences::class)->execute($experiences);
 
-        $education = CandidateEducationCollection::fromArray($data['education']);
+        $education = CandidateEducationCollection::fromArray($data['education'] ?? []);
         resolve(StoreCandidateEducation::class)->execute($education);
+
+        $experienceLevel = $data['experience_level'] ?? null;
 
         resolve(UpdateCandidateAction::class)->execute(new CandidateDTO(
             userID: auth()->user()->id,
@@ -193,7 +188,7 @@ class OnboardingWizard extends Page
             is_open_to_remote: $data['is_open_to_remote'] ?? true,
             expectedSalary: (float) $data['expected_salary'],
             expectedSalaryCurrency: $data['expected_salary_currency'] ?? 'USD',
-            experienceLevel: $data['experience_level'] ?? null,
+            experienceLevel: $experienceLevel instanceof BackedEnum ? $experienceLevel->value : $experienceLevel,
             selfIdentifiedGender: null,
             source: null,
             isOnboarded: true,
@@ -228,7 +223,6 @@ class OnboardingWizard extends Page
         return He4rtWizard::make()
             ->steps($steps)
             ->visible(fn () => $this->wizardVisible)
-            ->persistStepInQueryString()
             ->submitAction(new HtmlString(Blade::render(<<<'BLADE'
                         <x-filament::button
                             type="submit"

--- a/app-modules/panel-app/tests/Feature/Filament/Pages/OnboardingWizardTest.php
+++ b/app-modules/panel-app/tests/Feature/Filament/Pages/OnboardingWizardTest.php
@@ -102,9 +102,10 @@ it('should preserve form state across interactions', function (): void {
 
 it('should display appropriate error messages for failures', function (): void {
     livewire(OnboardingWizard::class)
+        ->set('wizardVisible', true)
         ->set('data.data_consent_given', false)
         ->call('handleRegistration')
-        ->assertNotified(__('panel-app::pages/onboarding.notifications.consent_required.title'));
+        ->assertHasFormErrors(['data_consent_given'], 'content');
 });
 
 describe('Resume Analysis Error Handling', function (): void {
@@ -134,9 +135,83 @@ describe('Resume Analysis Error Handling', function (): void {
     });
 });
 
+describe('Finalization validation (issue #166)', function (): void {
+    it('blocks finalization when phone is invalid for BR and does not persist', function (): void {
+        livewire(OnboardingWizard::class)
+            ->set('wizardVisible', true)
+            ->set('data.timezone', 'America/Sao_Paulo')
+            ->set('data.preferred_language', 'pt_BR')
+            ->set('data.phone', '+551198765432100')
+            ->set('data.data_consent_given', true)
+            ->set('data.expected_salary', '50000')
+            ->set('data.expected_salary_currency', 'BRL')
+            ->set('data.availability_date', now()->addDays(30)->format('Y-m-d'))
+            ->set('data.experience_level', ExperienceLevelEnum::Junior->value)
+            ->set('data.confirm_submission', true)
+            ->set('data.work_experiences', [])
+            ->set('data.education', [])
+            ->call('handleRegistration')
+            ->assertHasFormErrors(['phone'], 'content')
+            ->assertNoRedirect();
+
+        expect($this->candidate->fresh()->is_onboarded)->toBeFalse();
+    });
+
+    it('blocks finalization when a work experience is missing company_name without TypeError', function (): void {
+        livewire(OnboardingWizard::class)
+            ->set('wizardVisible', true)
+            ->set('data.timezone', 'America/Sao_Paulo')
+            ->set('data.preferred_language', 'pt_BR')
+            ->set('data.phone', '+5511987654321')
+            ->set('data.data_consent_given', true)
+            ->set('data.expected_salary', '50000')
+            ->set('data.expected_salary_currency', 'BRL')
+            ->set('data.availability_date', now()->addDays(30)->format('Y-m-d'))
+            ->set('data.experience_level', ExperienceLevelEnum::Junior->value)
+            ->set('data.confirm_submission', true)
+            ->set('data.work_experiences', [
+                'item-1' => [
+                    'company_name' => null,
+                    'description' => 'Some description',
+                    'start_date' => '2020-01-01',
+                    'end_date' => null,
+                    'is_currently_working_here' => true,
+                ],
+            ])
+            ->set('data.education', [])
+            ->call('handleRegistration')
+            ->assertHasFormErrors(['work_experiences.item-1.company_name'], 'content')
+            ->assertNoRedirect();
+
+        expect($this->candidate->fresh()->is_onboarded)->toBeFalse();
+    });
+
+    it('blocks finalization when data consent is not given', function (): void {
+        livewire(OnboardingWizard::class)
+            ->set('wizardVisible', true)
+            ->set('data.timezone', 'America/Sao_Paulo')
+            ->set('data.preferred_language', 'pt_BR')
+            ->set('data.phone', '+5511987654321')
+            ->set('data.data_consent_given', false)
+            ->set('data.expected_salary', '50000')
+            ->set('data.expected_salary_currency', 'BRL')
+            ->set('data.availability_date', now()->addDays(30)->format('Y-m-d'))
+            ->set('data.experience_level', ExperienceLevelEnum::Junior->value)
+            ->set('data.confirm_submission', true)
+            ->set('data.work_experiences', [])
+            ->set('data.education', [])
+            ->call('handleRegistration')
+            ->assertHasFormErrors(['data_consent_given'], 'content')
+            ->assertNoRedirect();
+
+        expect($this->candidate->fresh()->is_onboarded)->toBeFalse();
+    });
+});
+
 describe('Complete Registration Flow', function (): void {
     it('should complete full onboarding successfully', function (): void {
         livewire(OnboardingWizard::class)
+            ->set('wizardVisible', true)
             ->set('data.expected_salary', '75000')
             ->set('data.expected_salary_currency', 'USD')
             ->set('data.availability_date', now()->addDays(30)->format('Y-m-d'))
@@ -184,6 +259,7 @@ describe('Complete Registration Flow', function (): void {
         ];
 
         livewire(OnboardingWizard::class)
+            ->set('wizardVisible', true)
             ->set('data', $testData)
             ->call('handleRegistration');
 
@@ -201,6 +277,7 @@ describe('Complete Registration Flow', function (): void {
 
     it('should save phone number from onboarding data', function (): void {
         livewire(OnboardingWizard::class)
+            ->set('wizardVisible', true)
             ->set('data.expected_salary', '50000')
             ->set('data.expected_salary_currency', 'BRL')
             ->set('data.availability_date', now()->addDays(30)->format('Y-m-d'))
@@ -224,12 +301,14 @@ describe('Complete Registration Flow', function (): void {
 
     it('should mark candidate as onboarded with timestamp', function (): void {
         livewire(OnboardingWizard::class)
+            ->set('wizardVisible', true)
             ->set('data.expected_salary', '50000')
             ->set('data.expected_salary_currency', 'USD')
             ->set('data.availability_date', now()->addMonth()->format('Y-m-d'))
             ->set('data.experience_level', 'junior')
             ->set('data.timezone', 'UTC')
             ->set('data.preferred_language', 'en_US')
+            ->set('data.phone', '+5511987654321')
             ->set('data.confirm_submission', true)
             ->set('data.data_consent_given', true)
             ->set('data.work_experiences', [])
@@ -243,9 +322,10 @@ describe('Complete Registration Flow', function (): void {
 
     it('should handle registration without data consent', function (): void {
         livewire(OnboardingWizard::class)
+            ->set('wizardVisible', true)
             ->set('data.data_consent_given', false)
             ->call('handleRegistration')
-            ->assertNotified(__('panel-app::pages/onboarding.notifications.consent_required.title'));
+            ->assertHasFormErrors(['data_consent_given'], 'content');
 
         $candidate = $this->candidate->fresh();
         expect($candidate->is_onboarded)->toBeFalse();


### PR DESCRIPTION
## Resumo

Ao finalizar o cadastro inicial (onboarding) do candidato, o sistema **não conferia se as informações estavam completas e corretas antes de salvar**. Isso causava dois problemas:

- Em alguns casos, uma **tela de erro (500)** ao clicar em "Finalizar".
- Em outros, **dados inválidos eram salvos sem aviso** (por exemplo, um telefone fora do padrão).

## O que muda

Agora, ao clicar em **"Finalizar"**, o sistema confere todos os campos obrigatórios e o consentimento de dados **antes de salvar**:

- Se algo estiver faltando ou incorreto, o candidato vê a mensagem **diretamente no campo** e nada é salvo — sem tela de erro.
- Com tudo preenchido corretamente, o cadastro é concluído e o candidato segue para o painel normalmente.

Também removemos uma conferência duplicada de consentimento (agora coberta pela validação padrão) e um comportamento que permitia pular etapas pela URL sem validar.

## Observação importante (problema separado)

Durante a verificação, identificamos um problema **na parte visual** do passo-a-passo (o "wizard"): **depois de um erro ao tentar avançar de etapa**, o botão "Finalizar" passa a aparecer cedo demais e as marcações de etapa ("Finalizado/Aguardando") ficam inconsistentes.

Isso **não afeta a gravação dos dados** (que está correta com esta entrega) e foi registrado na issue #177 para tratamento à parte — possivelmente recriando o componente, a ser avaliado com o tech lead.

## Test plan

- [ ] Finalizar com telefone inválido: bloqueia e mostra o erro no campo, sem salvar
- [ ] Finalizar com campo obrigatório vazio: não gera tela de erro (500) e mostra a validação
- [ ] Finalizar sem consentimento: é bloqueado
- [ ] Finalizar com tudo válido: conclui o cadastro e redireciona ao painel
- [ ] (manual, no navegador) conferir o comportamento visual do wizard descrito na #177

Closes #166
Relacionado a #177