### PR TITLE
Remove etapas terminais que nunca eram usadas no pipeline

### DIFF
--- a/app-modules/panel-organization/tests/Feature/Livewire/PipelineStageDetailTest.php
+++ b/app-modules/panel-organization/tests/Feature/Livewire/PipelineStageDetailTest.php
@@ -17,6 +17,33 @@ use Livewire\Livewire;
 
 use function Pest\Laravel\actingAs;
 
+/**
+ * Terminal stages (Rejected/Declined) are no longer auto-created for requisitions,
+ * so tests covering the component's terminal handling must create them explicitly.
+ *
+ * @return array{0: Stage, 1: Stage}
+ */
+function makeTerminalStagesFor(Application $application): array
+{
+    $requisition = $application->requisition;
+
+    $rejected = Stage::factory()->create([
+        'stage_type' => StageTypeEnum::Rejected,
+        'job_requisition_id' => $requisition->getKey(),
+        'team_id' => $requisition->team_id,
+        'active' => true,
+    ]);
+
+    $declined = Stage::factory()->create([
+        'stage_type' => StageTypeEnum::Declined,
+        'job_requisition_id' => $requisition->getKey(),
+        'team_id' => $requisition->team_id,
+        'active' => true,
+    ]);
+
+    return [$rejected, $declined];
+}
+
 beforeEach(function (): void {
     $this->candidate = Candidate::factory()->create();
     $this->application = Application::factory()
@@ -260,20 +287,7 @@ it('handles application without current stage gracefully', function (): void {
 });
 
 it('excludes both terminal stages when current is not terminal', function (): void {
-    $rejected = $this->application
-        ->requisition
-        ->stages()
-        ->where('stage_type', StageTypeEnum::Rejected->value)
-        ->first();
-
-    $declined = $this->application
-        ->requisition
-        ->stages()
-        ->where('stage_type', StageTypeEnum::Declined->value)
-        ->first();
-
-    expect($rejected)->not->toBeNull()
-        ->and($declined)->not->toBeNull();
+    [$rejected, $declined] = makeTerminalStagesFor($this->application);
 
     Livewire::test(PipelineStageDetail::class, ['application' => $this->application->fresh()])
         ->call('goToStage', $rejected->id)
@@ -283,17 +297,7 @@ it('excludes both terminal stages when current is not terminal', function (): vo
 });
 
 it('includes Rejected in the pipeline when current_stage is Rejected', function (): void {
-    $rejected = $this->application
-        ->requisition
-        ->stages()
-        ->where('stage_type', StageTypeEnum::Rejected->value)
-        ->first();
-
-    $declined = $this->application
-        ->requisition
-        ->stages()
-        ->where('stage_type', StageTypeEnum::Declined->value)
-        ->first();
+    [$rejected, $declined] = makeTerminalStagesFor($this->application);
 
     $this->application->update(['current_stage_id' => $rejected->id]);
 
@@ -304,17 +308,7 @@ it('includes Rejected in the pipeline when current_stage is Rejected', function 
 });
 
 it('includes Declined in the pipeline when current_stage is Declined', function (): void {
-    $rejected = $this->application
-        ->requisition
-        ->stages()
-        ->where('stage_type', StageTypeEnum::Rejected->value)
-        ->first();
-
-    $declined = $this->application
-        ->requisition
-        ->stages()
-        ->where('stage_type', StageTypeEnum::Declined->value)
-        ->first();
+    [$rejected, $declined] = makeTerminalStagesFor($this->application);
 
     $this->application->update(['current_stage_id' => $declined->id]);
 

--- a/app-modules/recruitment/database/migrations/2026_05_30_000000_remove_terminal_pipeline_stages.php
+++ b/app-modules/recruitment/database/migrations/2026_05_30_000000_remove_terminal_pipeline_stages.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Recruitment\Stages\Enums\StageTypeEnum;
+use He4rt\Recruitment\Stages\Models\Stage;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * The terminal pseudo-stages (`rejected`/`declined`) were created by the
+     * JobRequisitionObserver for every requisition but never used by any
+     * transition — rejection is a status overlay, not a stage move. This
+     * migration removes the accumulated orphans.
+     *
+     * It is GUARDED: it counts every reference to the terminal stages first and
+     * aborts without deleting anything if any reference exists. The deletion only
+     * runs when all reference paths are empty, so production data is never lost.
+     */
+    public function up(): void
+    {
+        $terminalTypes = [
+            StageTypeEnum::Rejected->value,
+            StageTypeEnum::Declined->value,
+        ];
+
+        $terminalIds = DB::table('recruitment_pipeline_stages')
+            ->whereIn('stage_type', $terminalTypes)
+            ->pluck('id');
+
+        if ($terminalIds->isEmpty()) {
+            return;
+        }
+
+        $references = [
+            'applications.current_stage_id' => DB::table('applications')
+                ->whereIn('current_stage_id', $terminalIds)
+                ->count(),
+            'application_stage_history.from_stage_id' => DB::table('application_stage_history')
+                ->whereIn('from_stage_id', $terminalIds)
+                ->count(),
+            'application_stage_history.to_stage_id' => DB::table('application_stage_history')
+                ->whereIn('to_stage_id', $terminalIds)
+                ->count(),
+            'evaluations.stage_id' => DB::table('evaluations')
+                ->whereIn('stage_id', $terminalIds)
+                ->count(),
+            'recruitment_stage_interviewer.pipeline_stage_id' => DB::table('recruitment_stage_interviewer')
+                ->whereIn('pipeline_stage_id', $terminalIds)
+                ->count(),
+            'screening_questions.screenable_id' => DB::table('screening_questions')
+                ->where('screenable_type', Relation::getMorphAlias(Stage::class))
+                ->whereIn('screenable_id', $terminalIds)
+                ->count(),
+        ];
+
+        $referenced = array_filter($references, fn (int $count): bool => $count > 0);
+
+        if ($referenced !== []) {
+            $details = collect($referenced)
+                ->map(fn (int $count, string $path): string => sprintf('%s (%d)', $path, $count))
+                ->implode(', ');
+
+            throw new RuntimeException(
+                sprintf('Aborting migration: found references to terminal pipeline stages, refusing to delete. Referenced paths: %s.', $details)
+            );
+        }
+
+        DB::table('recruitment_pipeline_stages')
+            ->whereIn('id', $terminalIds)
+            ->delete();
+    }
+};

--- a/app-modules/recruitment/src/Requisitions/Observers/JobRequisitionObserver.php
+++ b/app-modules/recruitment/src/Requisitions/Observers/JobRequisitionObserver.php
@@ -33,8 +33,6 @@ final class JobRequisitionObserver
             ['type' => StageTypeEnum::Interview, 'duration' => 5],
             ['type' => StageTypeEnum::Offer, 'duration' => 5],
             ['type' => StageTypeEnum::Hired, 'duration' => 1],
-            ['type' => StageTypeEnum::Declined, 'duration' => 1],
-            ['type' => StageTypeEnum::Rejected, 'duration' => 1],
         ];
 
         foreach ($stagesConfig as $index => $config) {

--- a/app-modules/recruitment/tests/Feature/JobRequisitionTest.php
+++ b/app-modules/recruitment/tests/Feature/JobRequisitionTest.php
@@ -120,10 +120,10 @@ it('uses soft deletes', function (): void {
         ->and(JobRequisition::withTrashed()->find($requisition->getKey()))->not->toBeNull();
 });
 
-it('automatically creates 8 default stages when created', function (): void {
+it('automatically creates 6 default stages when created', function (): void {
     $requisition = JobRequisition::factory()->create();
 
-    expect($requisition->stages)->toHaveCount(8);
+    expect($requisition->stages)->toHaveCount(6);
 });
 
 it('creates stages with correct stage types', function (): void {
@@ -136,9 +136,16 @@ it('creates stages with correct stage types', function (): void {
         ->and($stageTypes)->toContain(StageTypeEnum::Assessment)
         ->and($stageTypes)->toContain(StageTypeEnum::Interview)
         ->and($stageTypes)->toContain(StageTypeEnum::Offer)
-        ->and($stageTypes)->toContain(StageTypeEnum::Hired)
-        ->and($stageTypes)->toContain(StageTypeEnum::Declined)
-        ->and($stageTypes)->toContain(StageTypeEnum::Rejected);
+        ->and($stageTypes)->toContain(StageTypeEnum::Hired);
+});
+
+it('does not create terminal pseudo-stages', function (): void {
+    $requisition = JobRequisition::factory()->create();
+
+    $stageTypes = $requisition->stages->pluck('stage_type')->toArray();
+
+    expect($stageTypes)->not->toContain(StageTypeEnum::Declined)
+        ->and($stageTypes)->not->toContain(StageTypeEnum::Rejected);
 });
 
 it('creates stages with correct display order', function (): void {
@@ -146,7 +153,7 @@ it('creates stages with correct display order', function (): void {
 
     $displayOrders = $requisition->stages->pluck('display_order')->sort()->values()->toArray();
 
-    expect($displayOrders)->toBe([1, 2, 3, 4, 5, 6, 7, 8]);
+    expect($displayOrders)->toBe([1, 2, 3, 4, 5, 6]);
 });
 
 it('creates stages with correct team_id', function (): void {

--- a/app-modules/recruitment/tests/Feature/RemoveTerminalPipelineStagesMigrationTest.php
+++ b/app-modules/recruitment/tests/Feature/RemoveTerminalPipelineStagesMigrationTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Applications\Models\Application;
+use He4rt\Applications\Models\ApplicationStageHistory;
+use He4rt\Feedback\Models\Evaluation;
+use He4rt\Recruitment\Requisitions\Models\JobRequisition;
+use He4rt\Recruitment\Staff\Recruiter\Recruiter;
+use He4rt\Recruitment\Stages\Enums\StageTypeEnum;
+use He4rt\Recruitment\Stages\Models\Stage;
+use He4rt\Screening\Models\ScreeningQuestion;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+function runRemoveTerminalStagesMigration(): void
+{
+    $path = base_path(
+        'app-modules/recruitment/database/migrations/2026_05_30_000000_remove_terminal_pipeline_stages.php'
+    );
+
+    (require $path)->up();
+}
+
+function makeTerminalStage(StageTypeEnum $type, ?JobRequisition $requisition = null): Stage
+{
+    $requisition ??= JobRequisition::factory()->create();
+
+    return Stage::factory()->create([
+        'stage_type' => $type,
+        'job_requisition_id' => $requisition->getKey(),
+        'team_id' => $requisition->team_id,
+    ]);
+}
+
+it('deletes orphan terminal stages when there are no references', function (): void {
+    $requisition = JobRequisition::factory()->create();
+    $nonTerminalCountBefore = $requisition->stages()->count();
+
+    $rejected = makeTerminalStage(StageTypeEnum::Rejected, $requisition);
+    $declined = makeTerminalStage(StageTypeEnum::Declined, $requisition);
+
+    runRemoveTerminalStagesMigration();
+
+    expect(Stage::withTrashed()->find($rejected->getKey()))->toBeNull()
+        ->and(Stage::withTrashed()->find($declined->getKey()))->toBeNull()
+        ->and(Stage::query()->count())->toBe($nonTerminalCountBefore);
+});
+
+it('is idempotent when there is nothing to delete', function (): void {
+    $requisition = JobRequisition::factory()->create();
+    $countBefore = Stage::query()->count();
+
+    runRemoveTerminalStagesMigration();
+    runRemoveTerminalStagesMigration();
+
+    expect(Stage::query()->count())->toBe($countBefore)
+        ->and($requisition->stages()->count())->toBe(6);
+});
+
+it('aborts without deleting anything when a terminal stage is referenced', function (string $path): void {
+    $terminal = makeTerminalStage(StageTypeEnum::Rejected);
+
+    match ($path) {
+        'applications.current_stage_id' => Application::factory()->create([
+            'current_stage_id' => $terminal->getKey(),
+        ]),
+        'application_stage_history.from_stage_id' => ApplicationStageHistory::factory()->create([
+            'from_stage_id' => $terminal->getKey(),
+        ]),
+        'application_stage_history.to_stage_id' => ApplicationStageHistory::factory()->create([
+            'to_stage_id' => $terminal->getKey(),
+        ]),
+        'evaluations.stage_id' => Evaluation::factory()->create([
+            'stage_id' => $terminal->getKey(),
+        ]),
+        'recruitment_stage_interviewer.pipeline_stage_id' => DB::table('recruitment_stage_interviewer')->insert([
+            'id' => Str::uuid()->toString(),
+            'pipeline_stage_id' => $terminal->getKey(),
+            'recruiter_id' => Recruiter::factory()->create()->getKey(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]),
+        'screening_questions.screenable_id' => ScreeningQuestion::factory()->create([
+            'screenable_type' => Relation::getMorphAlias(Stage::class),
+            'screenable_id' => $terminal->getKey(),
+        ]),
+    };
+
+    expect(fn () => runRemoveTerminalStagesMigration())->toThrow(RuntimeException::class);
+
+    expect(Stage::query()->find($terminal->getKey()))->not->toBeNull();
+})->with([
+    'applications.current_stage_id',
+    'application_stage_history.from_stage_id',
+    'application_stage_history.to_stage_id',
+    'evaluations.stage_id',
+    'recruitment_stage_interviewer.pipeline_stage_id',
+    'screening_questions.screenable_id',
+]);


### PR DESCRIPTION
## Problema

Toda vaga criada nascia com duas etapas extras no fim do funil de seleção — **"Rejeitado"** e **"Recusado"** — que na prática nunca eram usadas. Elas apareciam como opções soltas no campo **"Etapa de destino"** (ao mover um candidato no quadro), poluindo a lista e gerando confusão: a rejeição ou desistência de um candidato é controlada pelo **status da candidatura**, não por uma etapa do funil. O resultado eram cerca de 80 dessas etapas acumuladas no sistema sem nenhum uso real.

## Solução

- **Vagas novas** deixam de criar essas duas etapas extras.
- As etapas antigas acumuladas são **apagadas de forma segura**: antes de remover qualquer coisa, o sistema confere se alguma delas está sendo usada em algum lugar. Se encontrar qualquer uso, **não apaga nada** e avisa — ou seja, não há risco de perder dado de candidato.
- Nada relacionado a **rejeitar** ou marcar que um candidato **desistiu** muda: essas ações continuam funcionando exatamente como antes (elas vivem no status da candidatura, não nessas etapas).

## Resultado

O campo **"Etapa de destino"** passa a listar apenas as etapas reais do processo seletivo (Triagem, Avaliação, Entrevista, Proposta, Contratado), sem as duas opções confusas que nunca tiveram função.

> ⚠️ A remoção das etapas antigas mexe em dados de produção. A trava de segurança impede exclusão acidental, mas vale uma conferência humana antes do deploy.

Closes #169

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Terminal pipeline stages (Rejected and Declined) are no longer automatically created when setting up new requisitions. A migration safely removes existing terminal stages with validation checks.

* **Tests**
  * Updated tests to reflect the new default stage count and added migration validation tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->