### PR TITLE
Adiciona visão de etapas do candidato e ajusta botão de rejeição

### DIFF
--- a/app-modules/applications/src/Enums/ApplicationStatusEnum.php
+++ b/app-modules/applications/src/Enums/ApplicationStatusEnum.php
@@ -85,6 +85,24 @@ enum ApplicationStatusEnum: string implements HasColor, HasIcon, HasLabel
         };
     }
 
+    /**
+     * Whether the application can still be rejected. Distinct from isTerminal():
+     * a final outcome — be it negative (rejected, withdrawn, declined) or positive
+     * (offer accepted, hired) — no longer admits a rejection, while only the
+     * negative outcomes are painted as a terminal stop in the pipeline stepper.
+     */
+    public function allowsRejection(): bool
+    {
+        return match ($this) {
+            self::Rejected,
+            self::Withdrawn,
+            self::OfferDeclined,
+            self::OfferAccepted,
+            self::Hired => false,
+            default => true,
+        };
+    }
+
     public function getAction(Application $application): AbstractApplicationTransition
     {
         return match ($this) {

--- a/app-modules/applications/src/Enums/ApplicationStatusEnum.php
+++ b/app-modules/applications/src/Enums/ApplicationStatusEnum.php
@@ -67,7 +67,21 @@ enum ApplicationStatusEnum: string implements HasColor, HasIcon, HasLabel
             self::OfferDeclined => Heroicon::XMark,
             self::Hired => Heroicon::User,
             self::Rejected => Heroicon::XCircle,
-            self::Withdrawn => Heroicon::ArrowLeft,
+            self::Withdrawn => Heroicon::NoSymbol,
+        };
+    }
+
+    /**
+     * Whether the application has reached a terminal outcome that freezes it on
+     * its current stage as an overlay — rejection, candidate withdrawal or a
+     * declined offer. Terminal states no longer admit a rejection action and are
+     * signalled with a distinct colour in the pipeline stepper.
+     */
+    public function isTerminal(): bool
+    {
+        return match ($this) {
+            self::Rejected, self::Withdrawn, self::OfferDeclined => true,
+            default => false,
         };
     }
 

--- a/app-modules/applications/tests/Unit/ApplicationStatusEnumTest.php
+++ b/app-modules/applications/tests/Unit/ApplicationStatusEnumTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Support\Icons\Heroicon;
+use He4rt\Applications\Enums\ApplicationStatusEnum;
+
+it('uses a blocked symbol for a withdrawn application instead of a back arrow', function (): void {
+    expect(ApplicationStatusEnum::Withdrawn->getIcon())->toBe(Heroicon::NoSymbol);
+});
+
+it('resolves a Heroicon for every status case', function (ApplicationStatusEnum $status): void {
+    expect($status->getIcon())->toBeInstanceOf(Heroicon::class);
+})->with(ApplicationStatusEnum::cases());
+
+it('flags rejected, withdrawn and declined as terminal states', function (ApplicationStatusEnum $status): void {
+    expect($status->isTerminal())->toBeTrue();
+})->with([
+    ApplicationStatusEnum::Rejected,
+    ApplicationStatusEnum::Withdrawn,
+    ApplicationStatusEnum::OfferDeclined,
+]);
+
+it('does not flag in-progress states as terminal', function (ApplicationStatusEnum $status): void {
+    expect($status->isTerminal())->toBeFalse();
+})->with([
+    ApplicationStatusEnum::New,
+    ApplicationStatusEnum::InReview,
+    ApplicationStatusEnum::InProgress,
+    ApplicationStatusEnum::OfferExtended,
+    ApplicationStatusEnum::OfferAccepted,
+    ApplicationStatusEnum::Hired,
+]);

--- a/app-modules/applications/tests/Unit/ApplicationStatusEnumTest.php
+++ b/app-modules/applications/tests/Unit/ApplicationStatusEnumTest.php
@@ -31,3 +31,22 @@ it('does not flag in-progress states as terminal', function (ApplicationStatusEn
     ApplicationStatusEnum::OfferAccepted,
     ApplicationStatusEnum::Hired,
 ]);
+
+it('allows rejection only while the process is still open', function (ApplicationStatusEnum $status): void {
+    expect($status->allowsRejection())->toBeTrue();
+})->with([
+    ApplicationStatusEnum::New,
+    ApplicationStatusEnum::InReview,
+    ApplicationStatusEnum::InProgress,
+    ApplicationStatusEnum::OfferExtended,
+]);
+
+it('forbids rejection once the process has a final outcome', function (ApplicationStatusEnum $status): void {
+    expect($status->allowsRejection())->toBeFalse();
+})->with([
+    ApplicationStatusEnum::Rejected,
+    ApplicationStatusEnum::Withdrawn,
+    ApplicationStatusEnum::OfferDeclined,
+    ApplicationStatusEnum::OfferAccepted,
+    ApplicationStatusEnum::Hired,
+]);

--- a/app-modules/panel-organization/lang/en/view.php
+++ b/app-modules/panel-organization/lang/en/view.php
@@ -87,6 +87,7 @@ return [
             'empty_interviewers' => 'No interviewers assigned',
             'empty_evaluations' => 'No evaluations recorded in this stage',
             'hidden_warning' => 'Internal stage — visible to staff only',
+            'stepper_title' => 'Process stages',
         ],
     ],
     'tabs' => [

--- a/app-modules/panel-organization/lang/pt_BR/view.php
+++ b/app-modules/panel-organization/lang/pt_BR/view.php
@@ -87,6 +87,7 @@ return [
             'empty_interviewers' => 'Nenhum entrevistador atribuído',
             'empty_evaluations' => 'Sem avaliações registradas nesta etapa',
             'hidden_warning' => 'Etapa interna — visível apenas para a equipe',
+            'stepper_title' => 'Etapas do processo',
         ],
     ],
     'tabs' => [

--- a/app-modules/panel-organization/resources/views/livewire/pipeline-stage-detail.blade.php
+++ b/app-modules/panel-organization/resources/views/livewire/pipeline-stage-detail.blade.php
@@ -4,30 +4,104 @@
     use He4rt\Recruitment\Stages\Enums\StageTypeEnum;
 
     $stagesCount = $this->stages->count();
-    $progressPct = $stagesCount > 0 ? ($this->stageIndex / $stagesCount) * 100 : 0;
     $isCurrentRealStage = $this->application->currentStage?->id === $this->stage?->id;
 
+    // Status terminal (rejeitado/desistiu/recusou) congela a candidatura na etapa atual.
+    $terminal = $this->terminalStatus();
+    $terminalColor = $this->terminalColor();
+    $terminalBg = $terminalColor === "orange" ? "bg-orange-500" : "bg-red-500";
+    $terminalBorder = $terminalColor === "orange" ? "border-b-orange-500" : "border-b-red-500";
+    $terminalText = $terminalColor === "orange" ? "text-orange-500" : "text-red-500";
+    $terminalBanner = $terminalColor === "orange" ? "border-orange-500/40 bg-orange-500/10" : "border-red-500/40 bg-red-500/10";
+    $selectedIsTerminal = $this->stage && $this->isApplicationCurrent($this->stage) && $terminal !== null;
+
     $stageTypeClasses = fn (StageTypeEnum $type): string => match ($type) {
-        StageTypeEnum::New => 'bg-gray-500/10 text-gray-500 ring-gray-500/20',
-        StageTypeEnum::Screening => 'bg-yellow-500/10 text-yellow-600 ring-yellow-500/20',
-        StageTypeEnum::Assessment => 'bg-blue-500/10 text-blue-600 ring-blue-500/20',
-        StageTypeEnum::Interview => 'bg-emerald-500/10 text-emerald-600 ring-emerald-500/20',
-        StageTypeEnum::Offer => 'bg-green-500/10 text-green-600 ring-green-500/20',
-        StageTypeEnum::Hired => 'bg-emerald-500/10 text-emerald-600 ring-emerald-500/20',
-        StageTypeEnum::HiddenStage => 'bg-red-500/10 text-red-600 ring-red-500/20',
+        StageTypeEnum::New => "bg-gray-500/10 text-gray-500 ring-gray-500/20",
+        StageTypeEnum::Screening => "bg-yellow-500/10 text-yellow-600 ring-yellow-500/20",
+        StageTypeEnum::Assessment => "bg-blue-500/10 text-blue-600 ring-blue-500/20",
+        StageTypeEnum::Interview => "bg-emerald-500/10 text-emerald-600 ring-emerald-500/20",
+        StageTypeEnum::Offer => "bg-green-500/10 text-green-600 ring-green-500/20",
+        StageTypeEnum::Hired => "bg-emerald-500/10 text-emerald-600 ring-emerald-500/20",
+        StageTypeEnum::HiddenStage => "bg-red-500/10 text-red-600 ring-red-500/20",
     };
 
     $ratingClasses = fn (EvaluationRatingEnum $rating): string => match ($rating) {
-        EvaluationRatingEnum::StrongYes => 'bg-emerald-500/10 text-emerald-600 ring-emerald-500/20',
-        EvaluationRatingEnum::Yes => 'bg-green-500/10 text-green-600 ring-green-500/20',
-        EvaluationRatingEnum::Maybe => 'bg-amber-500/10 text-amber-600 ring-amber-500/20',
-        EvaluationRatingEnum::No => 'bg-orange-500/10 text-orange-600 ring-orange-500/20',
-        EvaluationRatingEnum::StrongNo => 'bg-red-500/10 text-red-600 ring-red-500/20',
+        EvaluationRatingEnum::StrongYes => "bg-emerald-500/10 text-emerald-600 ring-emerald-500/20",
+        EvaluationRatingEnum::Yes => "bg-green-500/10 text-green-600 ring-green-500/20",
+        EvaluationRatingEnum::Maybe => "bg-amber-500/10 text-amber-600 ring-amber-500/20",
+        EvaluationRatingEnum::No => "bg-orange-500/10 text-orange-600 ring-orange-500/20",
+        EvaluationRatingEnum::StrongNo => "bg-red-500/10 text-red-600 ring-red-500/20",
     };
 @endphp
 
 <div class="space-y-5">
+    {{-- =========================== STEPPER =========================== --}}
+    @if ($this->stages->isNotEmpty())
+        <div class="border-outline-low bg-elevation-01dp rounded-xl border p-4">
+            <h4 class="text-text-medium mb-4 flex items-center gap-2 text-xs font-semibold tracking-wider uppercase">
+                <x-he4rt::icon :icon="Heroicon::Squares2x2" size="xs" class="text-icon-medium" />
+                {{ __("panel-organization::view.pipeline.stage_detail.stepper_title") }}
+            </h4>
+            {{--
+                Barra de progresso segmentada: UMA barra contínua dividida em blocos (um por
+                etapa), pontas arredondadas. Verde = concluída, verde-claro = futura; se a
+                candidatura encerrou, a etapa onde parou fica vermelha (rejeitada/recusou) ou
+                laranja (desistiu). O caret aponta a etapa selecionada (nome no rótulo).
+            --}}
+            <div class="relative">
+                <div class="flex h-3 gap-px overflow-hidden rounded-full">
+                    @foreach ($this->stages as $st)
+                        @php
+                            $reached = $this->isReached($st);
+                            $isCurr = $this->isApplicationCurrent($st);
+                            $isTerminalPoint = $isCurr && $terminal !== null;
+                        @endphp
+
+                        <button
+                            type="button"
+                            title="{{ $st->name }}"
+                            @if ($reached) wire:click="goToStage('{{ $st->id }}')" @else disabled @endif
+                            class="{{ $isTerminalPoint ? $terminalBg : ($reached ? 'bg-success-500' : 'bg-success-500/25') }} {{ $isCurr && ! $isTerminalPoint ? 'animate-pulse' : '' }} {{ $reached ? 'cursor-pointer hover:brightness-110' : 'cursor-not-allowed' }} h-full flex-1 transition"
+                        >
+                            <span class="sr-only">{{ $st->name }}@if ($isTerminalPoint)· {{ $terminal->getLabel() }}
+                            @endif</span>
+                        </button>
+                    @endforeach
+                </div>
+                @if ($this->stage)
+                    <div
+                        class="{{ $selectedIsTerminal ? $terminalBorder : 'border-b-success-500' }} absolute top-full mt-1 h-0 w-0 -translate-x-1/2 border-x-[5px] border-b-[5px] border-x-transparent"
+                        style="left: {{ (($this->stageIndex - 0.5) / $this->stages->count()) * 100 }}%"
+                    ></div>
+                @endif
+            </div>
+            <div class="mt-3 flex items-center justify-between gap-2 text-xs">
+                <span class="{{ $selectedIsTerminal ? $terminalText : 'text-text-high' }} truncate font-medium">
+                    {{ $this->stage?->name }}
+                </span>
+                <span class="text-text-low shrink-0 font-mono tabular-nums">
+                    {{ $this->stageIndex }}/{{ $this->stages->count() }}
+                </span>
+            </div>
+        </div>
+    @endif
+
     @if ($this->stage)
+        {{-- =========================== TERMINAL STATUS BANNER =========================== --}}
+        @if ($selectedIsTerminal)
+            <div class="{{ $terminalBanner }} flex items-start gap-2.5 rounded-xl border p-3">
+                <x-he4rt::icon :icon="$terminal->getIcon()" size="sm" class="mt-0.5 shrink-0 {{ $terminalText }}" />
+                <div>
+                    <p class="{{ $terminalText }} text-sm font-semibold">
+                        {{ $terminal->getLabel() }}
+                    </p>
+                    @if ($this->rejectionReason())
+                        <p class="text-text-medium text-sm leading-relaxed">{{ $this->rejectionReason() }}</p>
+                    @endif
+                </div>
+            </div>
+        @endif
+
         {{-- =========================== HEADER =========================== --}}
         <div class="border-outline-low bg-elevation-01dp relative overflow-hidden rounded-xl border">
             <div class="from-primary via-primary/40 absolute inset-x-0 top-0 h-1 bg-gradient-to-r to-transparent"></div>
@@ -62,7 +136,7 @@
                                         ></span>
                                         <span class="bg-success relative inline-flex h-1.5 w-1.5 rounded-full"></span>
                                     </span>
-                                    {{ __('panel-organization::view.pipeline.stage_detail.current_stage') }}
+                                    {{ __("panel-organization::view.pipeline.stage_detail.current_stage") }}
                                 </span>
                             @endif
 
@@ -72,16 +146,6 @@
                                 </span>
                             @endif
                         </div>
-                    </div>
-                </div>
-
-                {{-- progresso no pipeline --}}
-                <div class="space-y-1.5">
-                    <div class="bg-elevation-03dp h-1.5 w-full overflow-hidden rounded-full">
-                        <div
-                            class="bg-primary h-full rounded-full transition-all duration-500"
-                            style="width: {{ $progressPct }}%"
-                        ></div>
                     </div>
                 </div>
 
@@ -96,7 +160,7 @@
                         class="bg-elevation-02dp text-text-medium inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-sm"
                     >
                         <x-he4rt::icon :icon="Heroicon::Clock" size="xs" class="text-icon-medium" />
-                        {{ trans_choice('panel-organization::view.pipeline.duration_days', $this->stage->expected_duration_days, ['count' => $this->stage->expected_duration_days]) }}
+                        {{ trans_choice("panel-organization::view.pipeline.duration_days", $this->stage->expected_duration_days, ["count" => $this->stage->expected_duration_days]) }}
                     </span>
                     @if ($this->stage->screeningQuestions->isNotEmpty())
                         <span
@@ -107,7 +171,7 @@
                                 size="xs"
                                 class="text-icon-medium"
                             />
-                            {{ trans_choice('panel-organization::view.pipeline.screening_questions', $this->stage->screeningQuestions->count(), ['count' => $this->stage->screeningQuestions->count()]) }}
+                            {{ trans_choice("panel-organization::view.pipeline.screening_questions", $this->stage->screeningQuestions->count(), ["count" => $this->stage->screeningQuestions->count()]) }}
                         </span>
                     @endif
                 </div>
@@ -119,7 +183,7 @@
             <div class="border-warning/40 bg-warning/10 flex items-start gap-2.5 rounded-xl border p-3">
                 <x-he4rt::icon :icon="Heroicon::LockClosed" size="sm" class="text-warning mt-0.5 shrink-0" />
                 <p class="text-warning text-sm leading-relaxed">
-                    {{ __('panel-organization::view.pipeline.stage_detail.hidden_warning') }}
+                    {{ __("panel-organization::view.pipeline.stage_detail.hidden_warning") }}
                 </p>
             </div>
         @endif
@@ -135,7 +199,7 @@
                     <x-he4rt::icon :icon="Heroicon::Clock" size="md" class="text-icon-low" />
                 </div>
                 <p class="text-text-medium text-base">
-                    {{ __('panel-organization::view.pipeline.stage_detail.empty_future') }}
+                    {{ __("panel-organization::view.pipeline.stage_detail.empty_future") }}
                 </p>
             </div>
         @else
@@ -144,7 +208,7 @@
                 <div class="flex items-center justify-between">
                     <h4 class="text-text-high flex items-center gap-2 text-base font-semibold">
                         <x-he4rt::icon :icon="Heroicon::ListBullet" size="sm" class="text-icon-medium" />
-                        {{ __('panel-organization::view.pipeline.stage_detail.timeline') }}
+                        {{ __("panel-organization::view.pipeline.stage_detail.timeline") }}
                     </h4>
                     @if ($this->timeline->isNotEmpty())
                         <span
@@ -158,7 +222,7 @@
                 @if ($this->timeline->isEmpty())
                     <div class="border-outline-low bg-elevation-01dp/50 rounded-lg border px-3 py-4 text-center">
                         <p class="text-text-low text-sm italic">
-                            {{ __('panel-organization::view.pipeline.stage_detail.empty_notes') }}
+                            {{ __("panel-organization::view.pipeline.stage_detail.empty_notes") }}
                         </p>
                     </div>
                 @else
@@ -173,7 +237,7 @@
                                 <div class="space-y-1.5">
                                     <div class="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
                                         <time class="text-text-high text-sm font-medium tabular-nums">
-                                            {{ $event->created_at->translatedFormat('d M Y · H:i') }}
+                                            {{ $event->created_at->translatedFormat("d M Y · H:i") }}
                                         </time>
                                         <span class="text-text-low text-xs">
                                             {{ $event->created_at->diffForHumans() }}
@@ -224,7 +288,7 @@
                 <div class="flex items-center justify-between">
                     <h4 class="text-text-high flex items-center gap-2 text-base font-semibold">
                         <x-he4rt::icon :icon="Heroicon::UserGroup" size="sm" class="text-icon-medium" />
-                        {{ __('panel-organization::view.pipeline.stage_detail.interviewers') }}
+                        {{ __("panel-organization::view.pipeline.stage_detail.interviewers") }}
                     </h4>
                     @if ($this->interviewers->isNotEmpty())
                         <span
@@ -238,7 +302,7 @@
                 @if ($this->interviewers->isEmpty())
                     <div class="border-outline-low bg-elevation-01dp/50 rounded-lg border px-3 py-4 text-center">
                         <p class="text-text-low text-sm italic">
-                            {{ __('panel-organization::view.pipeline.stage_detail.empty_interviewers') }}
+                            {{ __("panel-organization::view.pipeline.stage_detail.empty_interviewers") }}
                         </p>
                     </div>
                 @else
@@ -250,7 +314,7 @@
                                 <div
                                     class="bg-primary/15 text-primary flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-base font-semibold"
                                 >
-                                    {{ mb_strtoupper(mb_substr($interviewer->user?->name ?? '?', 0, 1)) }}
+                                    {{ mb_strtoupper(mb_substr($interviewer->user?->name ?? "?", 0, 1)) }}
                                 </div>
                                 <div class="min-w-0 flex-1">
                                     <div class="text-text-high truncate text-sm font-medium">
@@ -273,7 +337,7 @@
                 <div class="flex items-center justify-between">
                     <h4 class="text-text-high flex items-center gap-2 text-base font-semibold">
                         <x-he4rt::icon :icon="Heroicon::Star" size="sm" class="text-icon-medium" />
-                        {{ __('panel-organization::view.pipeline.stage_detail.evaluations') }}
+                        {{ __("panel-organization::view.pipeline.stage_detail.evaluations") }}
                     </h4>
                     @if ($this->evaluations->isNotEmpty())
                         <span
@@ -287,7 +351,7 @@
                 @if ($this->evaluations->isEmpty())
                     <div class="border-outline-low bg-elevation-01dp/50 rounded-lg border px-3 py-4 text-center">
                         <p class="text-text-low text-sm italic">
-                            {{ __('panel-organization::view.pipeline.stage_detail.empty_evaluations') }}
+                            {{ __("panel-organization::view.pipeline.stage_detail.empty_evaluations") }}
                         </p>
                     </div>
                 @else
@@ -379,7 +443,7 @@
                             />
                             <div class="min-w-0 flex-1">
                                 <div class="text-text-low text-xs font-semibold tracking-wider uppercase">
-                                    {{ __('panel-organization::view.pipeline.stage_detail.previous') }}
+                                    {{ __("panel-organization::view.pipeline.stage_detail.previous") }}
                                 </div>
                                 <div class="text-text-high mt-0.5 flex items-center gap-1.5">
                                     <x-he4rt::icon
@@ -402,7 +466,7 @@
                         >
                             <div class="min-w-0 flex-1">
                                 <div class="text-text-low text-right text-xs font-semibold tracking-wider uppercase">
-                                    {{ __('panel-organization::view.pipeline.stage_detail.next') }}
+                                    {{ __("panel-organization::view.pipeline.stage_detail.next") }}
                                 </div>
                                 <div class="text-text-high mt-0.5 flex items-center justify-end gap-1.5">
                                     <x-he4rt::icon
@@ -425,7 +489,7 @@
         @endif
     @else
         <p class="text-text-medium py-4 text-center text-base">
-            {{ __('panel-organization::view.pipeline.stage_detail.empty_future') }}
+            {{ __("panel-organization::view.pipeline.stage_detail.empty_future") }}
         </p>
     @endif
 </div>

--- a/app-modules/panel-organization/src/Filament/Resources/Recruitment/Applications/Actions/RejectApplicationAction.php
+++ b/app-modules/panel-organization/src/Filament/Resources/Recruitment/Applications/Actions/RejectApplicationAction.php
@@ -26,7 +26,7 @@ class RejectApplicationAction extends Action
             ->extraAttributes(fn () => ['class' => 'w-full'])
             ->outlined()
             ->requiresConfirmation()
-            ->disabled(fn (Application $record): bool => $record->status->isTerminal())
+            ->disabled(fn (Application $record): bool => ! $record->status->allowsRejection())
             ->modalHeading(__('panel-organization::filament.actions.reject_application.modal_heading'))
             ->modalDescription(__('panel-organization::filament.actions.reject_application.modal_description'))
             ->schema($this->formSchema())

--- a/app-modules/panel-organization/src/Filament/Resources/Recruitment/Applications/Actions/RejectApplicationAction.php
+++ b/app-modules/panel-organization/src/Filament/Resources/Recruitment/Applications/Actions/RejectApplicationAction.php
@@ -9,7 +9,6 @@ use Filament\Forms\Components\Field;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Notifications\Notification;
-use He4rt\Applications\Enums\ApplicationStatusEnum;
 use He4rt\Applications\Enums\RejectionReasonCategoryEnum;
 use He4rt\Applications\Models\Application;
 use Illuminate\Routing\Redirector;
@@ -27,7 +26,7 @@ class RejectApplicationAction extends Action
             ->extraAttributes(fn () => ['class' => 'w-full'])
             ->outlined()
             ->requiresConfirmation()
-            ->visible(fn (Application $record) => $record->status !== ApplicationStatusEnum::Rejected)
+            ->disabled(fn (Application $record): bool => $record->status->isTerminal())
             ->modalHeading(__('panel-organization::filament.actions.reject_application.modal_heading'))
             ->modalDescription(__('panel-organization::filament.actions.reject_application.modal_description'))
             ->schema($this->formSchema())

--- a/app-modules/panel-organization/src/Filament/Resources/Recruitment/Applications/Schemas/ApplicationInfolist.php
+++ b/app-modules/panel-organization/src/Filament/Resources/Recruitment/Applications/Schemas/ApplicationInfolist.php
@@ -118,7 +118,7 @@ class ApplicationInfolist
                                         ->slideOver()
                                         ->outlined()
                                         ->extraAttributes(fn () => ['class' => 'w-full'])
-                                        ->modalWidth(Width::Large)
+                                        ->modalWidth(Width::Medium)
                                         ->modalSubmitAction(false)
                                         ->modalCancelAction(false)
                                         ->modalHeading(fn (Application $record): string => __('panel-organization::view.pipeline.stage_detail.title'))

--- a/app-modules/panel-organization/src/Livewire/PipelineStageDetail.php
+++ b/app-modules/panel-organization/src/Livewire/PipelineStageDetail.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace He4rt\Organization\Livewire;
 
+use He4rt\Applications\Enums\ApplicationStatusEnum;
 use He4rt\Applications\Models\Application;
 use He4rt\Applications\Models\ApplicationStageHistory;
 use He4rt\Feedback\Models\Evaluation;
@@ -54,6 +55,7 @@ class PipelineStageDetail extends Component
         /** @var Application $application */
         $application = Application::query()
             ->with([
+                'currentStage',
                 'requisition.stages' => fn ($query) => $query
                     ->where('active', true)
                     ->orderBy('display_order'),
@@ -155,7 +157,9 @@ class PipelineStageDetail extends Component
             return null;
         }
 
-        return $this->stages->get($index + 1);
+        $next = $this->stages->get($index + 1);
+
+        return ($next instanceof Stage && $this->isReached($next)) ? $next : null;
     }
 
     #[Computed]
@@ -177,27 +181,112 @@ class PipelineStageDetail extends Component
 
     public function goToStage(string $stageId): void
     {
-        if ($this->stages->contains(fn (Stage $stage) => $stage->id === $stageId)) {
+        $target = $this->stages->firstWhere('id', $stageId);
+
+        if ($target instanceof Stage && $this->isReached($target)) {
             $this->currentStageId = $stageId;
+            $this->forgetStageComputeds();
         }
     }
 
     public function goToNextStage(): void
     {
-        if ($this->nextStage) {
-            $this->currentStageId = $this->nextStage->id;
+        $next = $this->nextStage;
+
+        if ($next instanceof Stage) {
+            $this->currentStageId = $next->id;
+            $this->forgetStageComputeds();
         }
     }
 
     public function goToPreviousStage(): void
     {
-        if ($this->prevStage) {
-            $this->currentStageId = $this->prevStage->id;
+        $prev = $this->prevStage;
+
+        if ($prev instanceof Stage) {
+            $this->currentStageId = $prev->id;
+            $this->forgetStageComputeds();
         }
+    }
+
+    /**
+     * A stage is "reached" when it is at or before the application's current stage
+     * (by display_order). Régua: o current_stage da candidatura — não depende de
+     * stageHistory (candidato recém-inscrito já alcançou seu stage atual).
+     */
+    public function isReached(Stage $stage): bool
+    {
+        $current = $this->application->currentStage;
+
+        return $current instanceof Stage && $stage->display_order <= $current->display_order;
+    }
+
+    public function isApplicationCurrent(Stage $stage): bool
+    {
+        $current = $this->application->currentStage;
+
+        return $current instanceof Stage && $stage->id === $current->id;
+    }
+
+    public function isRejected(): bool
+    {
+        return $this->application->status === ApplicationStatusEnum::Rejected;
+    }
+
+    public function rejectionReason(): ?string
+    {
+        if (! $this->isRejected()) {
+            return null;
+        }
+
+        return $this->application->rejection_reason_category?->getLabel();
+    }
+
+    /**
+     * The terminal status that "freezes" the application on its current stage as
+     * an overlay — rejection, withdrawal or a declined offer — or null when the
+     * application is still progressing through the journey.
+     */
+    public function terminalStatus(): ?ApplicationStatusEnum
+    {
+        return $this->application->status->isTerminal()
+            ? $this->application->status
+            : null;
+    }
+
+    /**
+     * Semantic color for the terminal marker: 'red' for negative exits (rejected
+     * or offer declined) and 'orange' for a candidate-initiated withdrawal.
+     */
+    public function terminalColor(): ?string
+    {
+        return match ($this->terminalStatus()) {
+            ApplicationStatusEnum::Rejected, ApplicationStatusEnum::OfferDeclined => 'red',
+            ApplicationStatusEnum::Withdrawn => 'orange',
+            default => null,
+        };
     }
 
     public function render(): Factory|View
     {
         return view('panel-organization::livewire.pipeline-stage-detail');
+    }
+
+    /**
+     * Invalidate the cached computeds that depend on the selected stage. Livewire
+     * memoizes #[Computed] for the whole request; without this, reading nextStage
+     * before mutating currentStageId re-renders the footer with a stale value.
+     */
+    private function forgetStageComputeds(): void
+    {
+        unset(
+            $this->stage,
+            $this->stageIndex,
+            $this->timeline,
+            $this->interviewers,
+            $this->evaluations,
+            $this->prevStage,
+            $this->nextStage,
+        );
     }
 }

--- a/app-modules/panel-organization/tests/Feature/Filament/Application/RejectApplicationActionVisibilityTest.php
+++ b/app-modules/panel-organization/tests/Feature/Filament/Application/RejectApplicationActionVisibilityTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\FilamentPanel;
+use Filament\Actions\Testing\TestAction;
+use He4rt\Applications\Enums\ApplicationStatusEnum;
+use He4rt\Applications\Models\Application;
+use He4rt\Organization\Filament\Resources\Recruitment\Applications\Pages\ViewApplication;
+use He4rt\Permissions\Roles;
+use He4rt\Recruitment\Requisitions\Models\JobPosting;
+use He4rt\Teams\Team;
+use He4rt\Users\User;
+use Livewire\Features\SupportTesting\Testable;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    filament()->setCurrentPanel(FilamentPanel::Organization->value);
+
+    $this->admin = User::factory()->create();
+    $this->admin->assignRole(Roles::Admin->value);
+    actingAs($this->admin);
+
+    $this->team = Team::factory()->create(['owner_id' => $this->admin->id]);
+
+    filament()->setTenant($this->team);
+});
+
+function rejectAction(): TestAction
+{
+    return TestAction::make('reject_application-action')->schemaComponent('quick-actions');
+}
+
+function viewApplicationFor(Application $application): Testable
+{
+    return livewire(ViewApplication::class, [
+        'tenant' => filament()->getTenant(),
+        'record' => $application->getKey(),
+    ]);
+}
+
+it('shows the reject action enabled for an in-progress application', function (): void {
+    $application = Application::factory()
+        ->withStatus(ApplicationStatusEnum::InProgress)
+        ->create(['team_id' => $this->team->id]);
+    JobPosting::factory()->for($application->requisition)->create();
+
+    viewApplicationFor($application)
+        ->assertOk()
+        ->assertActionVisible(rejectAction())
+        ->assertActionEnabled(rejectAction());
+});
+
+it('keeps the reject action visible but disabled for terminal applications', function (ApplicationStatusEnum $status): void {
+    $application = Application::factory()
+        ->withStatus($status)
+        ->create(['team_id' => $this->team->id]);
+    JobPosting::factory()->for($application->requisition)->create();
+
+    viewApplicationFor($application)
+        ->assertOk()
+        ->assertActionVisible(rejectAction())
+        ->assertActionDisabled(rejectAction());
+})->with([
+    'rejected' => ApplicationStatusEnum::Rejected,
+    'withdrawn' => ApplicationStatusEnum::Withdrawn,
+    'offer declined' => ApplicationStatusEnum::OfferDeclined,
+]);

--- a/app-modules/panel-organization/tests/Feature/Filament/Application/RejectApplicationActionVisibilityTest.php
+++ b/app-modules/panel-organization/tests/Feature/Filament/Application/RejectApplicationActionVisibilityTest.php
@@ -41,9 +41,9 @@ function viewApplicationFor(Application $application): Testable
     ]);
 }
 
-it('shows the reject action enabled for an in-progress application', function (): void {
+it('shows the reject action enabled while the application is still in progress', function (ApplicationStatusEnum $status): void {
     $application = Application::factory()
-        ->withStatus(ApplicationStatusEnum::InProgress)
+        ->withStatus($status)
         ->create(['team_id' => $this->team->id]);
     JobPosting::factory()->for($application->requisition)->create();
 
@@ -51,9 +51,14 @@ it('shows the reject action enabled for an in-progress application', function ()
         ->assertOk()
         ->assertActionVisible(rejectAction())
         ->assertActionEnabled(rejectAction());
-});
+})->with([
+    'new' => ApplicationStatusEnum::New,
+    'in review' => ApplicationStatusEnum::InReview,
+    'in progress' => ApplicationStatusEnum::InProgress,
+    'offer extended' => ApplicationStatusEnum::OfferExtended,
+]);
 
-it('keeps the reject action visible but disabled for terminal applications', function (ApplicationStatusEnum $status): void {
+it('keeps the reject action visible but disabled once the process reaches a final outcome', function (ApplicationStatusEnum $status): void {
     $application = Application::factory()
         ->withStatus($status)
         ->create(['team_id' => $this->team->id]);
@@ -67,4 +72,6 @@ it('keeps the reject action visible but disabled for terminal applications', fun
     'rejected' => ApplicationStatusEnum::Rejected,
     'withdrawn' => ApplicationStatusEnum::Withdrawn,
     'offer declined' => ApplicationStatusEnum::OfferDeclined,
+    'offer accepted' => ApplicationStatusEnum::OfferAccepted,
+    'hired' => ApplicationStatusEnum::Hired,
 ]);

--- a/app-modules/panel-organization/tests/Feature/Livewire/PipelineStageDetailTest.php
+++ b/app-modules/panel-organization/tests/Feature/Livewire/PipelineStageDetailTest.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use App\Enums\FilamentPanel;
+use He4rt\Applications\Enums\ApplicationStatusEnum;
+use He4rt\Applications\Enums\RejectionReasonCategoryEnum;
 use He4rt\Applications\Models\Application;
 use He4rt\Applications\Models\ApplicationStageHistory;
 use He4rt\Candidates\Models\Candidate;
@@ -59,15 +61,27 @@ it('mounts with current_stage_id from application', function (): void {
         ->assertSet('currentStageId', $this->application->current_stage_id);
 });
 
-it('navigates to the next stage in display_order', function (): void {
+it('does not navigate to a future (not yet reached) stage', function (): void {
+    // beforeEach leaves current at the first stage, so the rest are in the future
+    $futureStage = $this->stages->get(1);
+
+    Livewire::test(PipelineStageDetail::class, ['application' => $this->application->fresh()])
+        ->call('goToStage', $futureStage->id)
+        ->assertSet('currentStageId', $this->application->current_stage_id);
+});
+
+it('navigates to the next reached stage', function (): void {
     expect($this->stages->count())->toBeGreaterThan(1);
+
+    // application advanced to the last stage, so every stage is reached
+    $last = $this->stages->last();
+    $this->application->update(['current_stage_id' => $last->id]);
 
     $first = $this->stages->first();
     $second = $this->stages->get(1);
 
-    $this->application->update(['current_stage_id' => $first->id]);
-
     Livewire::test(PipelineStageDetail::class, ['application' => $this->application->fresh()])
+        ->call('goToStage', $first->id)
         ->call('goToNextStage')
         ->assertSet('currentStageId', $second->id);
 });
@@ -118,7 +132,7 @@ it('excludes inactive stages from navigation', function (): void {
         ->assertSet('currentStageId', $this->application->fresh()->current_stage_id);
 });
 
-it('includes hidden stages in navigation for staff users', function (): void {
+it('allows navigating to a reached hidden stage for staff users', function (): void {
     $hiddenStage = Stage::factory()
         ->for($this->application->requisition, 'requisition')
         ->state([
@@ -130,9 +144,92 @@ it('includes hidden stages in navigation for staff users', function (): void {
         ])
         ->create();
 
+    // application sits on the hidden stage, so it (and everything before) is reached
+    $this->application->update(['current_stage_id' => $hiddenStage->id]);
+
     Livewire::test(PipelineStageDetail::class, ['application' => $this->application->fresh()])
+        ->call('goToStage', $this->stages->first()->id)
+        ->assertSet('currentStageId', $this->stages->first()->id)
         ->call('goToStage', $hiddenStage->id)
         ->assertSet('currentStageId', $hiddenStage->id);
+});
+
+it('renders the stepper with the journey stages', function (): void {
+    Livewire::test(PipelineStageDetail::class, ['application' => $this->application->fresh()])
+        ->assertOk()
+        ->assertSee(__('panel-organization::view.pipeline.stage_detail.stepper_title'))
+        ->assertSee($this->stages->first()->name)
+        ->assertSee($this->stages->last()->name);
+});
+
+it('marks the rejection point and shows the banner when the application is rejected', function (): void {
+    $stoppedAt = $this->stages->get(2);
+
+    $this->application->update([
+        'current_stage_id' => $stoppedAt->id,
+        'status' => ApplicationStatusEnum::Rejected,
+        'rejection_reason_category' => RejectionReasonCategoryEnum::Qualifications,
+    ]);
+
+    Livewire::test(PipelineStageDetail::class, ['application' => $this->application->fresh()])
+        ->assertOk()
+        ->assertSee(ApplicationStatusEnum::Rejected->getLabel())
+        ->assertSee(RejectionReasonCategoryEnum::Qualifications->getLabel());
+});
+
+it('marks the withdrawal point when the candidate withdrew', function (): void {
+    $stoppedAt = $this->stages->get(2);
+
+    $this->application->update([
+        'current_stage_id' => $stoppedAt->id,
+        'status' => ApplicationStatusEnum::Withdrawn,
+    ]);
+
+    Livewire::test(PipelineStageDetail::class, ['application' => $this->application->fresh()])
+        ->assertOk()
+        ->assertSee(ApplicationStatusEnum::Withdrawn->getLabel());
+});
+
+it('marks a declined offer as a terminal point', function (): void {
+    $stoppedAt = $this->stages->get(4);
+
+    $this->application->update([
+        'current_stage_id' => $stoppedAt->id,
+        'status' => ApplicationStatusEnum::OfferDeclined,
+    ]);
+
+    Livewire::test(PipelineStageDetail::class, ['application' => $this->application->fresh()])
+        ->assertOk()
+        ->assertSee(ApplicationStatusEnum::OfferDeclined->getLabel());
+});
+
+it('treats the current stage as reached for a fresh application without history', function (): void {
+    // beforeEach leaves the application on the first stage with no stage history
+    $first = $this->stages->first();
+
+    Livewire::test(PipelineStageDetail::class, ['application' => $this->application->fresh()])
+        ->assertOk()
+        ->call('goToStage', $first->id)
+        ->assertSet('currentStageId', $first->id)
+        ->assertDontSee(__('panel-organization::view.pipeline.stage_detail.empty_future'));
+});
+
+it('refreshes the footer navigation after a single goToNextStage click', function (): void {
+    // application stopped at Offer (index 4): Interview is reached, Hired is future
+    $interview = $this->stages->get(3);
+    $offer = $this->stages->get(4);
+    $this->application->update([
+        'current_stage_id' => $offer->id,
+        'status' => ApplicationStatusEnum::OfferExtended,
+    ]);
+
+    Livewire::test(PipelineStageDetail::class, ['application' => $this->application->fresh()])
+        ->call('goToStage', $interview->id)
+        ->call('goToNextStage')
+        ->assertSet('currentStageId', $offer->id)
+        // Offer is the current stage, so there is no reached "next" — the footer
+        // "next" button must disappear after ONE click (no stale computed cache).
+        ->assertDontSee(__('panel-organization::view.pipeline.stage_detail.next'));
 });
 
 it('shows movedBy user name in timeline for the current stage', function (): void {

--- a/app-modules/panel-organization/tests/Feature/Livewire/PipelineStageDetailTest.php
+++ b/app-modules/panel-organization/tests/Feature/Livewire/PipelineStageDetailTest.php
@@ -203,6 +203,70 @@ it('marks a declined offer as a terminal point', function (): void {
         ->assertSee(ApplicationStatusEnum::OfferDeclined->getLabel());
 });
 
+it('paints the stopped stage red and the reached stages green for a rejected application', function (): void {
+    $stoppedAt = $this->stages->get(2);
+
+    $this->application->update([
+        'current_stage_id' => $stoppedAt->id,
+        'status' => ApplicationStatusEnum::Rejected,
+        'rejection_reason_category' => RejectionReasonCategoryEnum::Qualifications,
+    ]);
+
+    Livewire::test(PipelineStageDetail::class, ['application' => $this->application->fresh()])
+        ->assertOk()
+        // banner + caret use the red terminal palette (exclusive to terminal states)
+        ->assertSeeHtml('border-red-500/40')
+        ->assertSeeHtml('text-red-500')
+        // reached stages keep the valid success scale (regression for the bg-success typo)
+        ->assertSeeHtml('bg-success-500');
+});
+
+it('paints the stopped stage orange for a withdrawn application', function (): void {
+    $stoppedAt = $this->stages->get(2);
+
+    $this->application->update([
+        'current_stage_id' => $stoppedAt->id,
+        'status' => ApplicationStatusEnum::Withdrawn,
+    ]);
+
+    Livewire::test(PipelineStageDetail::class, ['application' => $this->application->fresh()])
+        ->assertOk()
+        ->assertSeeHtml('border-orange-500/40')
+        ->assertSeeHtml('text-orange-500')
+        ->assertDontSeeHtml('border-red-500/40');
+});
+
+it('does not show any terminal banner or color for an in-progress application', function (): void {
+    $this->application->update([
+        'current_stage_id' => $this->stages->get(2)->id,
+        'status' => ApplicationStatusEnum::InProgress,
+    ]);
+
+    Livewire::test(PipelineStageDetail::class, ['application' => $this->application->fresh()])
+        ->assertOk()
+        // the stepper still renders with the active (green) palette...
+        ->assertSeeHtml('bg-success-500')
+        // ...but no terminal overlay leaks in
+        ->assertDontSeeHtml('border-red-500/40')
+        ->assertDontSeeHtml('border-orange-500/40')
+        ->assertDontSee(ApplicationStatusEnum::Rejected->getLabel())
+        ->assertDontSee(ApplicationStatusEnum::Withdrawn->getLabel());
+});
+
+it('shows the rejection banner without a reason line when no category was recorded', function (): void {
+    $stoppedAt = $this->stages->get(2);
+
+    $this->application->update([
+        'current_stage_id' => $stoppedAt->id,
+        'status' => ApplicationStatusEnum::Rejected,
+        'rejection_reason_category' => null,
+    ]);
+
+    Livewire::test(PipelineStageDetail::class, ['application' => $this->application->fresh()])
+        ->assertOk()
+        ->assertSee(ApplicationStatusEnum::Rejected->getLabel());
+});
+
 it('treats the current stage as reached for a fresh application without history', function (): void {
     // beforeEach leaves the application on the first stage with no stage history
     $first = $this->stages->first();


### PR DESCRIPTION
## Contexto

Resolve a #172.

Ao abrir uma candidatura, faltava uma forma rápida de enxergar por **quais etapas do processo o candidato já passou** e em **que ponto ele está agora**. Além disso, quando uma candidatura já tinha um desfecho definido — reprovado, **desistiu** por conta própria, **recusou a proposta**, **aceitou a proposta** ou já foi **contratado** — o botão de "Rejeitar candidato" ainda aparecia clicável em vários desses casos. Isso abria espaço para reprovar alguém cujo processo já havia terminado, o que não faz sentido.

## O que muda na prática

- **Nova visão das etapas do processo.** No painel da candidatura, a ação "Ver detalhes do progresso" agora mostra uma barra com todas as etapas da vaga em sequência. As etapas pelas quais o candidato já passou ficam destacadas, a etapa atual fica em evidência, e as próximas aparecem mais apagadas. Dá pra navegar entre as etapas para ver os detalhes de cada uma (entrevistadores, avaliações e movimentações).

- **Sinalização clara de quando o processo foi encerrado por um caminho negativo.** Se a candidatura terminou sem sucesso, a etapa onde ela parou ganha uma cor que comunica o motivo:
  - 🔴 **vermelho** — candidato reprovado ou que recusou a proposta;
  - 🟠 **laranja** — candidato que desistiu por conta própria.
  
  Junto aparece um aviso com o status e, no caso de reprovação, o motivo registrado (quando houver).

- **Ícone de desistência mais intuitivo.** O ícone usado para "desistiu" era uma seta para a esquerda, que parecia um botão de "voltar". Foi trocado por um símbolo de bloqueio, que comunica melhor "saiu do processo".

- **Botão de rejeitar mais coerente.** Antes, o botão sumia em alguns casos e continuava clicável em outros. Agora ele segue uma regra única: **continua visível, porém bloqueado** sempre que a candidatura já chegou a um desfecho final — reprovado, desistente, proposta recusada, **proposta aceita** ou **contratado**. Enquanto o processo está em andamento, ele funciona normalmente.

## Como testar

1. Abra uma candidatura em andamento e clique em "Ver detalhes do progresso" — confira a barra de etapas e a navegação entre elas.
2. Abra candidaturas encerradas (reprovada, desistente e com proposta recusada) e verifique a cor e o aviso na etapa onde cada uma parou.
3. Nessas candidaturas encerradas — e também nas já contratadas ou com proposta aceita — confira que o botão "Rejeitar candidato" aparece, mas não pode ser clicado.
