### PR TITLE
docs: sanea READMEs do funil após remoção dos stages terminais

### DIFF
--- a/app-modules/applications/README.md
+++ b/app-modules/applications/README.md
@@ -104,6 +104,17 @@ Rejected      → Application rejected
 Withdrawn     → Candidate withdrew
 ```
 
+**Behavioral helpers:**
+
+- **`isTerminal(): bool`** — `true` for `Rejected`, `Withdrawn`, `OfferDeclined`.
+  These are the _negative_ final outcomes that freeze the application on its
+  current stage as an overlay (they do **not** move `current_stage_id`) and are
+  painted with a distinct colour in the pipeline stepper.
+- **`allowsRejection(): bool`** — `false` for `Rejected`, `Withdrawn`,
+  `OfferDeclined`, `OfferAccepted` **and** `Hired`. Distinct from `isTerminal()`:
+  the _positive_ finals (`OfferAccepted`/`Hired`) also forbid a rejection without
+  being a terminal stop. Drives the disabled state of the reject action.
+
 ### CandidateSourceEnum
 
 ```

--- a/app-modules/recruitment/README.md
+++ b/app-modules/recruitment/README.md
@@ -182,13 +182,19 @@ Principal  → Expert/Architect level
 ### StageTypeEnum
 
 ```
+New        → New application submission (🔵)
 Screening  → Initial review (🟡)
 Assessment → Skills assessment (🔵)
 Interview  → Interview round (🟢)
 Offer      → Offer stage (🟣)
 Hired      → Successfully hired (✅)
-Rejected   → Not selected (❌)
+HiddenStage→ Internal stage, staff-only (🔒)
 ```
+
+> **There are no "terminal" stages.** Rejection, withdrawal and a declined offer
+> are **status overlays** on `ApplicationStatusEnum` (see the Applications
+> module) — they freeze the application on its current stage and never consume a
+> pipeline stage. The `Rejected`/`Declined` stage types were removed in #168.
 
 ## Requisition Lifecycle
 
@@ -221,23 +227,28 @@ stateDiagram-v2
 
 ## Pipeline Configuration
 
+When a `JobRequisition` is created, `JobRequisitionObserver` seeds **6 default
+stages** (durations in days). Each stage is fully customizable per requisition.
+
 ```mermaid
 graph LR
-    subgraph Pipeline Stages
-        S1[Screening]
-        S2[Phone Screen]
-        S3[Technical Interview]
-        S4[Manager Interview]
-        S5[Offer]
+    subgraph Default Pipeline
+        S1["New (1d)"]
+        S2["Screening (3d)"]
+        S3["Assessment (7d)"]
+        S4["Interview (5d)"]
+        S5["Offer (5d)"]
+        S6["Hired (1d)"]
     end
 
-    S1 --> S2 --> S3 --> S4 --> S5
+    S1 --> S2 --> S3 --> S4 --> S5 --> S6
 
-    style S1 stroke:#f6ad55
-    style S2 stroke:#4299e1
+    style S1 stroke:#4299e1
+    style S2 stroke:#f6ad55
     style S3 stroke:#4299e1
     style S4 stroke:#38b2ac
     style S5 stroke:#9f7aea
+    style S6 stroke:#48bb78
 ```
 
 ## Entity Relationship Diagram


### PR DESCRIPTION
## Problema

A documentação de domínio de dois módulos ficou para trás das mudanças recentes do funil (#184, #168, #172), descrevendo conceitos que **não existem mais** no código.

## Solução

- **`recruitment/README.md`**: o `StageTypeEnum` listava `Rejected` (case **removido** no #168) e omitia `New`/`HiddenStage`. Corrigido para os 7 cases reais, com nota de que rejeição/desistência/recusa são **status overlay** (não consomem stage). O diagrama de pipeline foi atualizado para os **6 stages** que o `JobRequisitionObserver` realmente cria (New → Screening → Assessment → Interview → Offer → Hired).
- **`applications/README.md`**: documentados os métodos `isTerminal()` e `allowsRejection()` do `ApplicationStatusEnum` (adicionados no #172), explicando a diferença entre eles.

## Arquivos Alterados

- `app-modules/recruitment/README.md` — StageTypeEnum + pipeline padrão
- `app-modules/applications/README.md` — helpers isTerminal/allowsRejection

Sem mudança de código — apenas documentação.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  - Updated Applications module documentation with clarified descriptions of application status behaviors and restrictions.
  - Refined Recruitment module documentation with enhanced pipeline configuration details and stage type information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->