### PR TITLE
fix(recruitment): corrige e melhora o compartilhamento de link de vaga

### DIFF
--- a/app-modules/panel-organization/lang/en/filament.php
+++ b/app-modules/panel-organization/lang/en/filament.php
@@ -31,8 +31,8 @@ return [
 
     'actions' => [
         'copy_share_link' => [
-            'label' => 'Copy share link',
-            'tooltip_unavailable' => 'Publish a posting before sharing this job',
+            'label' => 'Share',
+            'tooltip_unavailable' => 'Publish this job before sharing it',
             'notification_copied' => 'Link copied to clipboard',
         ],
         'advance_stage' => [

--- a/app-modules/panel-organization/lang/pt_BR/filament.php
+++ b/app-modules/panel-organization/lang/pt_BR/filament.php
@@ -32,8 +32,8 @@ return [
 
     'actions' => [
         'copy_share_link' => [
-            'label' => 'Copiar link de compartilhamento',
-            'tooltip_unavailable' => 'Publique um anúncio antes de compartilhar esta vaga',
+            'label' => 'Compartilhar',
+            'tooltip_unavailable' => 'Publique a vaga antes de compartilhar',
             'notification_copied' => 'Link copiado para a área de transferência',
         ],
         'advance_stage' => [

--- a/app-modules/panel-organization/src/Filament/Resources/Recruitment/JobRequisitions/Actions/CopyJobShareLinkAction.php
+++ b/app-modules/panel-organization/src/Filament/Resources/Recruitment/JobRequisitions/Actions/CopyJobShareLinkAction.php
@@ -8,7 +8,9 @@ use App\Enums\FilamentPanel;
 use Filament\Actions\Action;
 use Filament\Support\Icons\Heroicon;
 use He4rt\App\Filament\Resources\JobRequisitions\JobRequisitionResource as CandidateJobRequisitionResource;
+use He4rt\Recruitment\Requisitions\Enums\RequisitionStatusEnum;
 use He4rt\Recruitment\Requisitions\Models\JobRequisition;
+use Illuminate\Support\Js;
 
 class CopyJobShareLinkAction extends Action
 {
@@ -28,8 +30,17 @@ class CopyJobShareLinkAction extends Action
             ->actionJs(fn (JobRequisition $record): string => $this->clipboardJs($record));
     }
 
+    /**
+     * URL pública de detalhe da vaga para compartilhamento, ou null quando a vaga não é
+     * compartilhável: precisa estar Published (mesma regra de visibilidade usada na busca
+     * e nas recomendações do candidato) e ter um anúncio com slug.
+     */
     public static function shareUrlFor(JobRequisition $record): ?string
     {
+        if ($record->status !== RequisitionStatusEnum::Published) {
+            return null;
+        }
+
         $slug = $record->post?->slug;
 
         if (blank($slug)) {
@@ -48,12 +59,29 @@ class CopyJobShareLinkAction extends Action
         return 'copyShareLink';
     }
 
+    /**
+     * Apresenta a action como botão somente-ícone para a tabela: clique rápido, sem
+     * ocupar espaço com texto. O tooltip (title) carrega o rótulo para discoverability
+     * quando habilitada, ou a explicação de indisponibilidade quando não há anúncio.
+     */
+    public function tableIconButton(): static
+    {
+        return $this
+            ->iconButton()
+            ->tooltip(fn (JobRequisition $record): string => blank(self::shareUrlFor($record))
+                ? __('panel-organization::filament.actions.copy_share_link.tooltip_unavailable')
+                : __('panel-organization::filament.actions.copy_share_link.label'));
+    }
+
     private function clipboardJs(JobRequisition $record): string
     {
-        $url = json_encode(self::shareUrlFor($record), JSON_THROW_ON_ERROR);
-        $message = json_encode(
+        // Js::from() escapa as aspas como sequências hex ("), evitando aspas duplas
+        // literais. O ComponentAttributeBag do Laravel serializa atributos com
+        // str_replace('"', '\"', ...) — aspas duplas no JS quebrariam o atributo HTML e
+        // truncariam o handler Alpine. json_encode() produzia exatamente esse problema.
+        $url = Js::from(self::shareUrlFor($record));
+        $message = Js::from(
             __('panel-organization::filament.actions.copy_share_link.notification_copied'),
-            JSON_THROW_ON_ERROR,
         );
 
         return <<<JS

--- a/app-modules/panel-organization/src/Filament/Resources/Recruitment/JobRequisitions/Pages/EditJobRequisition.php
+++ b/app-modules/panel-organization/src/Filament/Resources/Recruitment/JobRequisitions/Pages/EditJobRequisition.php
@@ -8,6 +8,7 @@ use Filament\Actions\DeleteAction;
 use Filament\Actions\ForceDeleteAction;
 use Filament\Actions\RestoreAction;
 use Filament\Resources\Pages\EditRecord;
+use He4rt\Organization\Filament\Resources\Recruitment\JobRequisitions\Actions\CopyJobShareLinkAction;
 use He4rt\Organization\Filament\Resources\Recruitment\JobRequisitions\Actions\DuplicateJobRequisitionAction;
 use He4rt\Organization\Filament\Resources\Recruitment\JobRequisitions\JobRequisitionResource;
 use He4rt\Recruitment\Requisitions\Models\JobRequisition;
@@ -28,6 +29,7 @@ class EditJobRequisition extends EditRecord
     protected function getHeaderActions(): array
     {
         return [
+            CopyJobShareLinkAction::make(),
             DuplicateJobRequisitionAction::make(),
             DeleteAction::make(),
             ForceDeleteAction::make(),

--- a/app-modules/panel-organization/src/Filament/Resources/Recruitment/JobRequisitions/Tables/JobRequisitionsTable.php
+++ b/app-modules/panel-organization/src/Filament/Resources/Recruitment/JobRequisitions/Tables/JobRequisitionsTable.php
@@ -117,6 +117,7 @@ class JobRequisitionsTable
                 TrashedFilter::make(),
             ])
             ->recordActions([
+                CopyJobShareLinkAction::make()->tableIconButton(),
                 ActionGroup::make([
                     EditAction::make(),
                     Action::make('kanban')
@@ -124,7 +125,6 @@ class JobRequisitionsTable
                         ->icon(Heroicon::OutlinedViewColumns)
                         ->url(fn (JobRequisition $record): string => JobRequisitionResource::getUrl('kanban',
                             ['record' => $record->id])),
-                    CopyJobShareLinkAction::make(),
                     DuplicateJobRequisitionAction::make(),
                 ]),
             ])

--- a/app-modules/panel-organization/tests/Feature/JobRequisition/CopyJobShareLinkTest.php
+++ b/app-modules/panel-organization/tests/Feature/JobRequisition/CopyJobShareLinkTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 use App\Enums\FilamentPanel;
 use Filament\Actions\Testing\TestAction;
 use He4rt\Organization\Filament\Resources\Recruitment\JobRequisitions\Actions\CopyJobShareLinkAction;
+use He4rt\Organization\Filament\Resources\Recruitment\JobRequisitions\Pages\EditJobRequisition;
 use He4rt\Organization\Filament\Resources\Recruitment\JobRequisitions\Pages\ListJobRequisitions;
 use He4rt\Organization\Filament\Resources\Recruitment\JobRequisitions\Pages\ViewJobRequisition;
+use He4rt\Recruitment\Requisitions\Enums\RequisitionStatusEnum;
 use He4rt\Recruitment\Requisitions\Models\JobPosting;
 use He4rt\Recruitment\Requisitions\Models\JobRequisition;
 use He4rt\Recruitment\Staff\Recruiter\Recruiter;
@@ -14,6 +16,28 @@ use He4rt\Teams\Department;
 use Livewire\Livewire;
 
 use function Pest\Laravel\actingAs;
+
+/**
+ * Extrai o valor do atributo `x-on:click` — já parseado pelas regras de atributo HTML,
+ * como o navegador faria — do primeiro elemento cujo handler contenha $needle.
+ * Retorna null quando nenhum handler intacto contém o trecho (ex.: atributo truncado
+ * por escaping inválido de aspas).
+ */
+function clickHandlerContaining(string $html, string $needle): ?string
+{
+    $dom = new DOMDocument();
+    @$dom->loadHTML('<!DOCTYPE html><html><body>'.$html.'</body></html>', LIBXML_NOERROR | LIBXML_NOWARNING);
+
+    foreach ($dom->getElementsByTagName('*') as $node) {
+        $handler = $node->getAttribute('x-on:click');
+
+        if ($handler !== '' && str_contains($handler, $needle)) {
+            return $handler;
+        }
+    }
+
+    return null;
+}
 
 beforeEach(function (): void {
     filament()->setCurrentPanel(FilamentPanel::Organization->value);
@@ -23,12 +47,14 @@ beforeEach(function (): void {
     $this->department = Department::factory()->forRecruiter($this->recruiter)->createOne();
     filament()->setTenant($this->team);
 
+    // Default Published: a action só faz sentido para vagas publicadas, então o happy
+    // path parte daí. Testes que precisam de outro status sobrescrevem via $attributes.
     $this->makeRequisition = fn (array $attributes = []): JobRequisition => JobRequisition::factory()
         ->for($this->team)
         ->for($this->department)
         ->for($this->recruiter, 'recruiter')
         ->for($this->recruiter->user, 'createdBy')
-        ->create($attributes);
+        ->create(['status' => RequisitionStatusEnum::Published, ...$attributes]);
 });
 
 it('builds the candidate detail URL from the job posting slug', function (): void {
@@ -45,6 +71,13 @@ it('builds the candidate detail URL from the job posting slug', function (): voi
 
 it('returns null when the requisition has no job posting', function (): void {
     $requisition = ($this->makeRequisition)();
+
+    expect(CopyJobShareLinkAction::shareUrlFor($requisition->fresh()))->toBeNull();
+});
+
+it('returns null when the requisition is not published', function (): void {
+    $requisition = ($this->makeRequisition)(['status' => RequisitionStatusEnum::Draft]);
+    JobPosting::factory()->for($requisition, 'jobRequisition')->create();
 
     expect(CopyJobShareLinkAction::shareUrlFor($requisition->fresh()))->toBeNull();
 });
@@ -72,6 +105,14 @@ it('disables the copy share link action when the job has no posting', function (
         ->assertActionDisabled(TestAction::make('copyShareLink')->table($requisition));
 });
 
+it('disables the copy share link action when the job is not published', function (): void {
+    $requisition = ($this->makeRequisition)(['status' => RequisitionStatusEnum::Draft]);
+    JobPosting::factory()->for($requisition, 'jobRequisition')->create();
+
+    Livewire::test(ListJobRequisitions::class)
+        ->assertActionDisabled(TestAction::make('copyShareLink')->table($requisition));
+});
+
 it('shows the copy share link action in the view page header', function (): void {
     $requisition = ($this->makeRequisition)();
     JobPosting::factory()->for($requisition, 'jobRequisition')->create();
@@ -79,4 +120,30 @@ it('shows the copy share link action in the view page header', function (): void
     Livewire::test(ViewJobRequisition::class, ['record' => $requisition->getKey()])
         ->assertActionExists('copyShareLink')
         ->assertActionEnabled('copyShareLink');
+});
+
+it('shows the copy share link action in the edit page header', function (): void {
+    $this->recruiter->user->givePermissionTo('update_job_requisitions');
+
+    $requisition = ($this->makeRequisition)();
+    JobPosting::factory()->for($requisition, 'jobRequisition')->create();
+
+    Livewire::test(EditJobRequisition::class, ['record' => $requisition->getKey()])
+        ->assertActionExists('copyShareLink')
+        ->assertActionEnabled('copyShareLink');
+});
+
+it('renders a clipboard handler that survives HTML attribute encoding intact', function (): void {
+    $requisition = ($this->makeRequisition)();
+    $posting = JobPosting::factory()->for($requisition, 'jobRequisition')->create();
+
+    $html = Livewire::test(ViewJobRequisition::class, ['record' => $requisition->getKey()])->html();
+
+    $handler = clickHandlerContaining($html, 'navigator.clipboard.writeText');
+
+    expect($handler)->not->toBeNull();
+    expect($handler)
+        ->toContain('navigator.clipboard.writeText')
+        ->toContain('FilamentNotification')
+        ->toContain($posting->slug);
 });


### PR DESCRIPTION
## O que estava acontecendo

A funcionalidade de **compartilhar o link de uma vaga** (entregue no #185 / issue #179) não funcionava na prática. No painel da organização, ao clicar no botão para copiar o link da vaga, **nada acontecia**: o link não ia para a área de transferência e nenhuma confirmação aparecia. Na prática, o recrutador não conseguia compartilhar a vaga.

## O que mudou

- ✅ **Agora funciona de verdade:** ao clicar, o link da vaga é copiado e aparece a confirmação "Link copiado".
- ⚡ **Mais rápido de usar:** o botão virou um ícone direto na linha da tabela de vagas (um clique), em vez de ficar escondido dentro do menu "⋮" junto com as outras opções.
- ✂️ **Texto mais curto:** o botão agora diz apenas **"Compartilhar"** (antes era "Copiar link de compartilhamento").
- 📝 **Também na edição:** o botão de compartilhar passa a aparecer também na tela de **edição** da vaga, não só na de visualização.
- 🔒 **Só compartilha vaga publicada:** só é possível copiar o link de vagas que estão de fato **publicadas**. Para vagas em rascunho, pausadas, fechadas ou canceladas, o botão fica **desativado**, com uma dica explicando que é preciso publicar a vaga antes. Isso evita compartilhar links de vagas que ainda não deveriam estar circulando.

## Como validar

1. No painel da organização, abra a lista de vagas.
2. Em uma vaga **publicada**, clique no ícone 🔗 de compartilhar (na linha da tabela ou no topo da vaga).
3. Confirme que aparece a notificação "Link copiado" e que, ao colar, o link abre a página pública da vaga.
4. Em uma vaga **não publicada**, confirme que o botão fica desativado com a dica explicativa.

Coberto por testes automáticos e verificado manualmente no navegador.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Share button added to job requisition edit page header.
  * Share functionality now available as an icon button in the job table view.

* **Bug Fixes**
  * Share link now requires published job status before enabling.

* **Documentation**
  * Updated UI labels and tooltips for share actions in English and Portuguese (Brazil).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->