### PR TITLE
Corrige rejeição de candidatura: histórico, avisos e regra de oferta

### DIFF
--- a/app-modules/applications/README.md
+++ b/app-modules/applications/README.md
@@ -111,9 +111,12 @@ Withdrawn     → Candidate withdrew
   current stage as an overlay (they do **not** move `current_stage_id`) and are
   painted with a distinct colour in the pipeline stepper.
 - **`allowsRejection(): bool`** — `false` for `Rejected`, `Withdrawn`,
-  `OfferDeclined`, `OfferAccepted` **and** `Hired`. Distinct from `isTerminal()`:
-  the _positive_ finals (`OfferAccepted`/`Hired`) also forbid a rejection without
-  being a terminal stop. Drives the disabled state of the reject action.
+  `OfferDeclined`, `OfferExtended`, `OfferAccepted` **and** `Hired`. Distinct from
+  `isTerminal()`: the _positive_ finals (`OfferAccepted`/`Hired`) also forbid a
+  rejection without being a terminal stop. Once an offer is extended the negative
+  path is a _declined_ offer, not a rejection — the state machine
+  (`OfferExtendedTransition`) only models `OfferAccepted`/`OfferDeclined`/`Withdrawn`,
+  so this guard is aligned to it. Drives the disabled state of the reject action.
 
 ### CandidateSourceEnum
 

--- a/app-modules/applications/src/Actions/RejectApplicationAction.php
+++ b/app-modules/applications/src/Actions/RejectApplicationAction.php
@@ -7,17 +7,18 @@ namespace He4rt\Applications\Actions;
 use He4rt\Applications\Enums\ApplicationStatusEnum;
 use He4rt\Applications\Enums\RejectionReasonCategoryEnum;
 use He4rt\Applications\Models\Application;
+use He4rt\Applications\Services\Transitions\TransitionData;
 
 final class RejectApplicationAction
 {
     public function execute(string $applicationId, RejectionReasonCategoryEnum $reason, ?string $details = null): void
     {
-        $application = Application::query()->where('id', $applicationId)->first();
-        $application->update([
-            'status' => ApplicationStatusEnum::Rejected,
-            'rejection_reason_category' => $reason,
+        $application = Application::query()->findOrFail($applicationId);
+
+        $application->current_step->handle(TransitionData::fromArray([
+            'to_status' => ApplicationStatusEnum::Rejected,
+            'rejection_reason_category' => $reason->value,
             'rejection_reason_details' => $details,
-            'rejected_at' => now(),
-        ]);
+        ]));
     }
 }

--- a/app-modules/applications/src/Enums/ApplicationStatusEnum.php
+++ b/app-modules/applications/src/Enums/ApplicationStatusEnum.php
@@ -90,6 +90,11 @@ enum ApplicationStatusEnum: string implements HasColor, HasIcon, HasLabel
      * a final outcome — be it negative (rejected, withdrawn, declined) or positive
      * (offer accepted, hired) — no longer admits a rejection, while only the
      * negative outcomes are painted as a terminal stop in the pipeline stepper.
+     *
+     * Once an offer is extended, the negative path is a declined offer, not a
+     * rejection: the state machine (OfferExtendedTransition) only models
+     * OfferAccepted/OfferDeclined/Withdrawn, so this guard is aligned to it and
+     * forbids rejecting an OfferExtended application.
      */
     public function allowsRejection(): bool
     {
@@ -97,6 +102,7 @@ enum ApplicationStatusEnum: string implements HasColor, HasIcon, HasLabel
             self::Rejected,
             self::Withdrawn,
             self::OfferDeclined,
+            self::OfferExtended,
             self::OfferAccepted,
             self::Hired => false,
             default => true,

--- a/app-modules/applications/tests/Unit/ApplicationStatusEnumTest.php
+++ b/app-modules/applications/tests/Unit/ApplicationStatusEnumTest.php
@@ -38,12 +38,12 @@ it('allows rejection only while the process is still open', function (Applicatio
     ApplicationStatusEnum::New,
     ApplicationStatusEnum::InReview,
     ApplicationStatusEnum::InProgress,
-    ApplicationStatusEnum::OfferExtended,
 ]);
 
 it('forbids rejection once the process has a final outcome', function (ApplicationStatusEnum $status): void {
     expect($status->allowsRejection())->toBeFalse();
 })->with([
+    ApplicationStatusEnum::OfferExtended,
     ApplicationStatusEnum::Rejected,
     ApplicationStatusEnum::Withdrawn,
     ApplicationStatusEnum::OfferDeclined,

--- a/app-modules/panel-organization/tests/Feature/Filament/Application/ChangeApplicationStatusTest.php
+++ b/app-modules/panel-organization/tests/Feature/Filament/Application/ChangeApplicationStatusTest.php
@@ -3,12 +3,20 @@
 declare(strict_types=1);
 
 use App\Enums\FilamentPanel;
+use Filament\Actions\Testing\TestAction;
 use He4rt\Applications\Actions\RejectApplicationAction;
+use He4rt\Applications\Enums\ApplicationStatusEnum;
 use He4rt\Applications\Enums\RejectionReasonCategoryEnum;
+use He4rt\Applications\Events\ApplicationStatusChanged;
+use He4rt\Applications\Exceptions\InvalidTransitionException;
 use He4rt\Applications\Models\Application;
 use He4rt\Organization\Filament\Resources\Recruitment\Applications\Pages\ViewApplication;
+use He4rt\Permissions\Roles;
 use He4rt\Recruitment\Requisitions\Models\JobPosting;
-use He4rt\Recruitment\Staff\Recruiter\Recruiter;
+use He4rt\Recruitment\Stages\Models\Stage;
+use He4rt\Teams\Team;
+use He4rt\Users\User;
+use Illuminate\Support\Facades\Event;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\assertDatabaseHas;
@@ -16,14 +24,18 @@ use function Pest\Livewire\livewire;
 
 beforeEach(function (): void {
     filament()->setCurrentPanel(FilamentPanel::Organization->value);
-    $this->evaluator = Recruiter::factory()->createOne();
-    actingAs($this->evaluator->user);
-    $this->evaluator->user->givePermissionTo('view_any_applications');
 
-    $this->application = Application::factory()->createOne();
-    $requisition = $this->application->requisition;
-    JobPosting::factory()->for($requisition)->create();
-    filament()->setTenant($this->application->team);
+    $this->admin = User::factory()->create();
+    $this->admin->assignRole(Roles::Admin->value);
+    actingAs($this->admin);
+
+    $this->team = Team::factory()->create(['owner_id' => $this->admin->id]);
+    $this->application = Application::factory()
+        ->withStatus(ApplicationStatusEnum::InReview)
+        ->create(['team_id' => $this->team->id]);
+
+    JobPosting::factory()->for($this->application->requisition)->create();
+    filament()->setTenant($this->team);
 });
 
 it('should render', function (): void {
@@ -34,16 +46,101 @@ it('should render', function (): void {
 });
 
 it('should be able to reject an application', function (): void {
+    Event::fake([ApplicationStatusChanged::class]);
+
     $sut = new RejectApplicationAction();
     $sut->execute(
         applicationId: $this->application->getKey(),
         reason: RejectionReasonCategoryEnum::Availability,
         details: 'n sei'
     );
+
     assertDatabaseHas(Application::class, [
-        'rejection_reason_details' => 'n sei',
         'id' => $this->application->getKey(),
+        'status' => ApplicationStatusEnum::Rejected,
+        'rejection_reason_details' => 'n sei',
         'rejection_reason_category' => RejectionReasonCategoryEnum::Availability,
     ]);
-    // Just for now
+
+    // Auditoria: a rejeição passa pela máquina de estados, gravando uma linha de
+    // histórico como overlay (mesmo estágio) e atribuída ao sistema (moved_by null).
+    $history = $this->application->stageHistory()->get();
+
+    expect($history)->toHaveCount(1)
+        ->and($history->first()->moved_by)->toBeNull()
+        ->and($history->first()->from_stage_id)->toBe($this->application->current_stage_id)
+        ->and($history->first()->to_stage_id)->toBe($this->application->current_stage_id);
+
+    Event::assertDispatched(ApplicationStatusChanged::class);
+});
+
+it('rejects through the Filament action, persisting status and notifying', function (): void {
+    livewire(ViewApplication::class, [
+        'tenant' => filament()->getTenant(),
+        'record' => $this->application->getKey(),
+    ])
+        ->callAction(
+            TestAction::make('reject_application-action')->schemaComponent('quick-actions'),
+            data: [
+                'rejection_reason_category' => RejectionReasonCategoryEnum::Compensation->value,
+                'rejection_reason_details' => 'budget acima do teto',
+            ],
+        )
+        ->assertHasNoActionErrors()
+        ->assertNotified();
+
+    assertDatabaseHas(Application::class, [
+        'id' => $this->application->getKey(),
+        'status' => ApplicationStatusEnum::Rejected,
+        'rejection_reason_category' => RejectionReasonCategoryEnum::Compensation,
+    ]);
+});
+
+it('requires a rejection reason category in the Filament action', function (): void {
+    livewire(ViewApplication::class, [
+        'tenant' => filament()->getTenant(),
+        'record' => $this->application->getKey(),
+    ])
+        ->callAction(
+            TestAction::make('reject_application-action')->schemaComponent('quick-actions'),
+            data: [
+                'rejection_reason_category' => null,
+                'rejection_reason_details' => 'sem categoria',
+            ],
+        )
+        ->assertHasActionErrors(['rejection_reason_category' => 'required']);
+
+    expect($this->application->refresh()->status)->toBe(ApplicationStatusEnum::InReview);
+});
+
+it('refuses to reject an application that already has an offer extended', function (): void {
+    $application = Application::factory()->withOffer()->createOne();
+
+    expect(fn () => new RejectApplicationAction()->execute(
+        applicationId: $application->getKey(),
+        reason: RejectionReasonCategoryEnum::Other,
+    ))->toThrow(InvalidTransitionException::class);
+
+    expect($application->refresh()->status)->toBe(ApplicationStatusEnum::OfferExtended);
+});
+
+it('keeps the application on its current stage when rejected (overlay)', function (): void {
+    $application = Application::factory()
+        ->withStatus(ApplicationStatusEnum::InReview)
+        ->createOne();
+    $stage = Stage::factory()->create(['job_requisition_id' => $application->requisition_id]);
+    $application->update(['current_stage_id' => $stage->id]);
+
+    new RejectApplicationAction()->execute(
+        applicationId: $application->getKey(),
+        reason: RejectionReasonCategoryEnum::Other,
+    );
+
+    $application->refresh();
+    $history = $application->stageHistory()->first();
+
+    expect($application->current_stage_id)->toBe($stage->id)
+        ->and($application->status)->toBe(ApplicationStatusEnum::Rejected)
+        ->and($history->from_stage_id)->toBe($stage->id)
+        ->and($history->to_stage_id)->toBe($stage->id);
 });

--- a/app-modules/panel-organization/tests/Feature/Filament/Application/RejectApplicationActionVisibilityTest.php
+++ b/app-modules/panel-organization/tests/Feature/Filament/Application/RejectApplicationActionVisibilityTest.php
@@ -55,7 +55,6 @@ it('shows the reject action enabled while the application is still in progress',
     'new' => ApplicationStatusEnum::New,
     'in review' => ApplicationStatusEnum::InReview,
     'in progress' => ApplicationStatusEnum::InProgress,
-    'offer extended' => ApplicationStatusEnum::OfferExtended,
 ]);
 
 it('keeps the reject action visible but disabled once the process reaches a final outcome', function (ApplicationStatusEnum $status): void {
@@ -69,6 +68,7 @@ it('keeps the reject action visible but disabled once the process reaches a fina
         ->assertActionVisible(rejectAction())
         ->assertActionDisabled(rejectAction());
 })->with([
+    'offer extended' => ApplicationStatusEnum::OfferExtended,
     'rejected' => ApplicationStatusEnum::Rejected,
     'withdrawn' => ApplicationStatusEnum::Withdrawn,
     'offer declined' => ApplicationStatusEnum::OfferDeclined,


### PR DESCRIPTION
Closes #160.

## Problema

Quando alguém do RH **reprovava** um candidato, o sistema fazia isso por um atalho que pulava o "registro oficial": a candidatura ficava marcada como reprovada, mas **não deixava rastro no histórico** e **não disparava os avisos** que o resto do sistema espera. A reprovação era, na prática, invisível para auditoria. (É o mesmo tipo de atalho já corrigido em outras partes do produto.)

Junto disso havia uma incoerência: mesmo depois que a empresa **já tinha enviado uma proposta** ao candidato, o botão "Reprovar" continuava clicável — só que o fluxo oficial não previa reprovar nesse ponto.

## Solução

- **Reprovar agora passa pelo caminho oficial.** Toda reprovação registra o movimento no histórico e dispara o aviso de mudança de status. Como tudo acontece de uma vez só (de forma atômica), não existe mais o risco de a candidatura ficar "reprovada pela metade" caso algo falhe no meio do caminho.
- **Botão coerente com o fluxo.** Depois que uma proposta foi enviada, o botão "Reprovar" fica visível porém **bloqueado** — nesse estágio o caminho negativo é o candidato **recusar a proposta**, não a empresa reprovar.
- A reprovação continua sendo um "carimbo por cima": **não tira** o candidato da etapa em que ele está.

Para o candidato/usuário final, **nada muda visualmente** — o status final continua "Rejeitado", com os mesmos campos preenchidos. A diferença é interna: agora tudo fica rastreável e os avisos do sistema funcionam.

## Testes

Cobrimos automaticamente:
- reprovar gera o registro de histórico e dispara o aviso (auditoria);
- reprovar pelo botão do painel da organização, incluindo a validação de motivo obrigatório;
- o botão fica bloqueado quando já existe proposta enviada — e o sistema recusa a tentativa, mesmo se forçada;
- reprovar não move o candidato da etapa atual.

Suíte completa: 1042 testes (1040 passando, 2 skipped). Pint e PHPStan limpos.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated rejection workflow: applications with extended offers can no longer be rejected. Users must use the decline offer action instead.

* **Documentation**
  * Clarified rejection eligibility documentation to distinguish offer-extended applications from terminal states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->