### PR TITLE
fix(panel-org): trata end_date nula nas abas da candidatura

### DIFF
--- a/app-modules/candidates/src/Models/Candidate.php
+++ b/app-modules/candidates/src/Models/Candidate.php
@@ -122,15 +122,15 @@ class Candidate extends BaseModel implements HasMedia
         return $this->is_onboarded;
     }
 
-    public function getExperienceDuration(WorkExperience $experience): string
+    public function getExperienceDuration(WorkExperience $experience): ?string
     {
-        $end = $experience->is_currently_working_here
-            ? now()
-            : ($experience->end_date ?? now());
+        $months = $experience->durationInMonths();
 
-        $months = (float) $experience->start_date->diffInMonths($end);
+        if ($months === null) {
+            return null;
+        }
 
-        return $this->formatExperienceTime($months);
+        return $this->formatExperienceTime((float) $months);
     }
 
     public function calculateProfileCompletion(): int
@@ -315,13 +315,7 @@ class Candidate extends BaseModel implements HasMedia
     private function calculateTotalExperienceMonths(): int
     {
         return (int) $this->workExperiences
-            ->sum(function (WorkExperience $exp) {
-                $end = $exp->is_currently_working_here
-                    ? now()
-                    : ($exp->end_date ?? now());
-
-                return $exp->start_date->diffInMonths($end);
-            });
+            ->sum(fn (WorkExperience $exp): int => $exp->durationInMonths() ?? 0);
     }
 
     private function formatExperienceTime(float $totalMonths): string

--- a/app-modules/candidates/src/Models/Education.php
+++ b/app-modules/candidates/src/Models/Education.php
@@ -20,7 +20,7 @@ use Illuminate\Support\Carbon;
  * @property string $degree
  * @property string $field_of_study
  * @property Carbon $start_date
- * @property Carbon $end_date
+ * @property Carbon|null $end_date
  * @property bool $is_enrolled
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
@@ -43,6 +43,23 @@ class Education extends BaseModel
     public function candidate(): BelongsTo
     {
         return $this->belongsTo(Candidate::class);
+    }
+
+    /**
+     * Total months between the start date and the effective end date.
+     *
+     * Returns null when the degree is completed but has no recorded end date,
+     * so the duration is genuinely unknown and must not be assumed as "until today".
+     */
+    public function durationInMonths(): ?int
+    {
+        $end = $this->is_enrolled ? now() : $this->end_date;
+
+        if ($end === null) {
+            return null;
+        }
+
+        return (int) $this->start_date->diffInMonths($end);
     }
 
     protected function casts(): array

--- a/app-modules/candidates/src/Models/WorkExperience.php
+++ b/app-modules/candidates/src/Models/WorkExperience.php
@@ -20,7 +20,7 @@ use Illuminate\Support\Collection;
  * @property string $company_name
  * @property string $description
  * @property Carbon $start_date
- * @property Carbon $end_date
+ * @property Carbon|null $end_date
  * @property bool $is_currently_working_here
  * @property Collection<int, string> $metadata
  * @property Carbon|null $created_at
@@ -44,6 +44,23 @@ class WorkExperience extends BaseModel
     public function candidate(): BelongsTo
     {
         return $this->belongsTo(Candidate::class);
+    }
+
+    /**
+     * Total months between the start date and the effective end date.
+     *
+     * Returns null when the role is in the past but has no recorded end date,
+     * so the duration is genuinely unknown and must not be assumed as "until today".
+     */
+    public function durationInMonths(): ?int
+    {
+        $end = $this->is_currently_working_here ? now() : $this->end_date;
+
+        if ($end === null) {
+            return null;
+        }
+
+        return (int) $this->start_date->diffInMonths($end);
     }
 
     protected function casts(): array

--- a/app-modules/candidates/tests/Feature/CandidateTest.php
+++ b/app-modules/candidates/tests/Feature/CandidateTest.php
@@ -96,3 +96,38 @@ it('calculates individual experience duration correctly', function (): void {
     expect($duration)->toBeString()
         ->and($duration)->not->toBeEmpty();
 });
+
+it('returns null experience duration for a past role without an end date', function (): void {
+    $candidate = Candidate::factory()->create();
+
+    $experience = WorkExperience::factory()->create([
+        'candidate_id' => $candidate->id,
+        'is_currently_working_here' => false,
+        'end_date' => null,
+        'start_date' => now()->subMonths(10),
+    ]);
+
+    expect($candidate->getExperienceDuration($experience))->toBeNull();
+});
+
+it('excludes unmeasurable experiences from the total experience time', function (): void {
+    $candidate = Candidate::factory()->create();
+
+    // Mensurável: 12 meses entre início e término.
+    WorkExperience::factory()->create([
+        'candidate_id' => $candidate->id,
+        'is_currently_working_here' => false,
+        'start_date' => now()->subMonths(24),
+        'end_date' => now()->subMonths(12),
+    ]);
+
+    // Imensurável: emprego passado sem data de término não pode inflar o total.
+    WorkExperience::factory()->create([
+        'candidate_id' => $candidate->id,
+        'is_currently_working_here' => false,
+        'end_date' => null,
+        'start_date' => now()->subMonths(60),
+    ]);
+
+    expect($candidate->total_experience_months)->toBe(12);
+});

--- a/app-modules/candidates/tests/Feature/EducationTest.php
+++ b/app-modules/candidates/tests/Feature/EducationTest.php
@@ -43,3 +43,32 @@ it('uses soft deletes', function (): void {
     expect($education->deleted_at)->not->toBeNull()
         ->and(Education::withTrashed()->find($education->id))->not->toBeNull();
 });
+
+it('returns null duration for a completed degree without an end date', function (): void {
+    $education = Education::factory()->create([
+        'is_enrolled' => false,
+        'end_date' => null,
+        'start_date' => now()->subMonths(10),
+    ]);
+
+    expect($education->durationInMonths())->toBeNull();
+});
+
+it('counts duration up to today while still enrolled', function (): void {
+    $education = Education::factory()->create([
+        'is_enrolled' => true,
+        'start_date' => now()->subMonths(6),
+    ]);
+
+    expect($education->durationInMonths())->toBe(6);
+});
+
+it('counts duration between start and end for a completed degree', function (): void {
+    $education = Education::factory()->create([
+        'is_enrolled' => false,
+        'start_date' => now()->subMonths(48),
+        'end_date' => now()->subMonths(12),
+    ]);
+
+    expect($education->durationInMonths())->toBe(36);
+});

--- a/app-modules/candidates/tests/Feature/WorkExperienceTest.php
+++ b/app-modules/candidates/tests/Feature/WorkExperienceTest.php
@@ -50,3 +50,32 @@ it('uses soft deletes', function (): void {
     expect($workExperience->deleted_at)->not->toBeNull()
         ->and(WorkExperience::withTrashed()->find($workExperience->id))->not->toBeNull();
 });
+
+it('returns null duration for a past role without an end date', function (): void {
+    $workExperience = WorkExperience::factory()->create([
+        'is_currently_working_here' => false,
+        'end_date' => null,
+        'start_date' => now()->subMonths(10),
+    ]);
+
+    expect($workExperience->durationInMonths())->toBeNull();
+});
+
+it('counts duration up to today for a currently held role', function (): void {
+    $workExperience = WorkExperience::factory()->create([
+        'is_currently_working_here' => true,
+        'start_date' => now()->subMonths(6),
+    ]);
+
+    expect($workExperience->durationInMonths())->toBe(6);
+});
+
+it('counts duration between start and end for a finished role', function (): void {
+    $workExperience = WorkExperience::factory()->create([
+        'is_currently_working_here' => false,
+        'start_date' => now()->subMonths(24),
+        'end_date' => now()->subMonths(12),
+    ]);
+
+    expect($workExperience->durationInMonths())->toBe(12);
+});

--- a/app-modules/panel-organization/resources/views/components/applications/tabs/education.blade.php
+++ b/app-modules/panel-organization/resources/views/components/applications/tabs/education.blade.php
@@ -71,10 +71,9 @@
                 @php
                     $degreeCategory = categorizeDegree($degree->degree);
                     $isCompleted = ! $degree->is_enrolled;
-                    $endDate = $degree->end_date ?? now();
-                    $duration = $degree->start_date->diffInMonths($endDate);
-                    $durationYears = (int) floor($duration / 12);
-                    $durationMonths = (int) $duration % 12;
+                    $durationMonthsTotal = $degree->durationInMonths();
+                    $durationYears = $durationMonthsTotal !== null ? intdiv($durationMonthsTotal, 12) : 0;
+                    $durationMonths = $durationMonthsTotal !== null ? $durationMonthsTotal % 12 : 0;
 
                     $categoryColors = [
                         'PhD' => 'purple',
@@ -116,17 +115,19 @@
                                 {{ $degree->start_date->format('Y') }} -
                                 {{ $degree->is_enrolled ? __('panel-organization::view.tabs.work_experience.present') : $degree->end_date?->format('Y') ?? '—' }}
                             </p>
-                            <p class="text-text-medium text-xs">
-                                @if ($durationYears > 0)
-                                    {{ trans_choice('panel-organization::view.time.year', $durationYears, ['count' => $durationYears]) }}
+                            @if ($durationMonthsTotal !== null)
+                                <p class="text-text-medium text-xs">
+                                    @if ($durationYears > 0)
+                                        {{ trans_choice('panel-organization::view.time.year', $durationYears, ['count' => $durationYears]) }}
 
-                                    @if ($durationMonths > 0)
+                                        @if ($durationMonths > 0)
+                                            {{ trans_choice('panel-organization::view.time.month', $durationMonths, ['count' => $durationMonths]) }}
+                                        @endif
+                                    @else
                                         {{ trans_choice('panel-organization::view.time.month', $durationMonths, ['count' => $durationMonths]) }}
                                     @endif
-                                @else
-                                    {{ trans_choice('panel-organization::view.time.month', $durationMonths, ['count' => $durationMonths]) }}
-                                @endif
-                            </p>
+                                </p>
+                            @endif
                         </div>
                     </div>
 

--- a/app-modules/panel-organization/resources/views/components/applications/tabs/education.blade.php
+++ b/app-modules/panel-organization/resources/views/components/applications/tabs/education.blade.php
@@ -114,7 +114,7 @@
                         <div class="text-right">
                             <p class="text-text-high text-sm font-semibold">
                                 {{ $degree->start_date->format('Y') }} -
-                                {{ $degree->is_enrolled ? __('panel-organization::view.tabs.work_experience.present') : $degree->end_date->format('Y') }}
+                                {{ $degree->is_enrolled ? __('panel-organization::view.tabs.work_experience.present') : $degree->end_date?->format('Y') ?? '—' }}
                             </p>
                             <p class="text-text-medium text-xs">
                                 @if ($durationYears > 0)
@@ -147,7 +147,7 @@
                                 <span class="flex items-center gap-1">
                                     <x-he4rt::icon :icon="\Filament\Support\Icons\Heroicon::CalendarDays" size="xs" />
                                     {{ $degree->start_date->format('M Y') }} -
-                                    {{ $degree->is_enrolled ? __('panel-organization::view.tabs.work_experience.present') : $degree->end_date->format('M Y') }}
+                                    {{ $degree->is_enrolled ? __('panel-organization::view.tabs.work_experience.present') : $degree->end_date?->format('M Y') ?? '—' }}
                                 </span>
                                 @if (! $degree->is_enrolled)
                                     <span class="flex items-center gap-1">

--- a/app-modules/panel-organization/resources/views/components/applications/tabs/work-experience.blade.php
+++ b/app-modules/panel-organization/resources/views/components/applications/tabs/work-experience.blade.php
@@ -145,7 +145,9 @@
                                         {{ $startDate->format('M Y') }} -
                                         {{ $isCurrent ? __('panel-organization::view.tabs.work_experience.present') : $endDate?->format('M Y') ?? '—' }}
                                     </span>
-                                    <span>{{ $durationText }}</span>
+                                    @if ($durationText !== null)
+                                        <span>{{ $durationText }}</span>
+                                    @endif
                                 </div>
 
                                 {{-- Description --}}

--- a/app-modules/panel-organization/resources/views/components/applications/tabs/work-experience.blade.php
+++ b/app-modules/panel-organization/resources/views/components/applications/tabs/work-experience.blade.php
@@ -143,7 +143,7 @@
                                     <span class="flex items-center gap-1">
                                         <x-he4rt::icon :icon="\Filament\Support\Icons\Heroicon::Calendar" size="xs" />
                                         {{ $startDate->format('M Y') }} -
-                                        {{ $isCurrent ? __('panel-organization::view.tabs.work_experience.present') : $endDate->format('M Y') }}
+                                        {{ $isCurrent ? __('panel-organization::view.tabs.work_experience.present') : $endDate?->format('M Y') ?? '—' }}
                                     </span>
                                     <span>{{ $durationText }}</span>
                                 </div>

--- a/app-modules/panel-organization/tests/Feature/Filament/Application/EducationTabTest.php
+++ b/app-modules/panel-organization/tests/Feature/Filament/Application/EducationTabTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\FilamentPanel;
+use He4rt\Applications\Models\Application;
+use He4rt\Candidates\Models\Candidate;
+use He4rt\Candidates\Models\Education;
+use He4rt\Organization\Filament\Resources\Recruitment\Applications\Pages\ViewApplication;
+use He4rt\Permissions\Roles;
+use He4rt\Recruitment\Requisitions\Models\JobPosting;
+use He4rt\Recruitment\Staff\Recruiter\Recruiter;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    $this->candidate = Candidate::factory()->create();
+    $this->application = Application::factory()
+        ->for($this->candidate, 'candidate')
+        ->create();
+    JobPosting::factory()->for($this->application->requisition, 'jobRequisition')->createOne();
+    $this->team = $this->application->team;
+    $this->recruiter = Recruiter::factory()->for($this->team, 'team')->create();
+    $this->recruiter->user->assignRole(Roles::SuperAdmin->value);
+    actingAs($this->recruiter->user);
+
+    filament()->setCurrentPanel(FilamentPanel::Organization->value);
+    filament()->setTenant($this->team);
+});
+
+it('renders the education tab for a completed degree without an end date', function (): void {
+    Education::factory()
+        ->for($this->candidate, 'candidate')
+        ->create([
+            'is_enrolled' => false,
+            'end_date' => null,
+        ]);
+
+    livewire(ViewApplication::class, ['record' => $this->application->getKey()])
+        ->assertOk();
+});

--- a/app-modules/panel-organization/tests/Feature/Filament/Application/WorkExperienceTabTest.php
+++ b/app-modules/panel-organization/tests/Feature/Filament/Application/WorkExperienceTabTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\FilamentPanel;
+use He4rt\Applications\Models\Application;
+use He4rt\Candidates\Models\Candidate;
+use He4rt\Candidates\Models\WorkExperience;
+use He4rt\Organization\Filament\Resources\Recruitment\Applications\Pages\ViewApplication;
+use He4rt\Permissions\Roles;
+use He4rt\Recruitment\Requisitions\Models\JobPosting;
+use He4rt\Recruitment\Staff\Recruiter\Recruiter;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    $this->candidate = Candidate::factory()->create();
+    $this->application = Application::factory()
+        ->for($this->candidate, 'candidate')
+        ->create();
+    JobPosting::factory()->for($this->application->requisition, 'jobRequisition')->createOne();
+    $this->team = $this->application->team;
+    $this->recruiter = Recruiter::factory()->for($this->team, 'team')->create();
+    $this->recruiter->user->assignRole(Roles::SuperAdmin->value);
+    actingAs($this->recruiter->user);
+
+    filament()->setCurrentPanel(FilamentPanel::Organization->value);
+    filament()->setTenant($this->team);
+});
+
+it('renders the work experience tab for a past job without an end date', function (): void {
+    WorkExperience::factory()
+        ->for($this->candidate, 'candidate')
+        ->create([
+            'is_currently_working_here' => false,
+            'end_date' => null,
+        ]);
+
+    livewire(ViewApplication::class, ['record' => $this->application->getKey()])
+        ->assertOk();
+});


### PR DESCRIPTION
## 🐛 Problemas resolvidos

Este PR corrige dois problemas relacionados, ambos disparados pelo mesmo gatilho: **um candidato que não preencheu a data de término** de um emprego anterior ou de um curso concluído.

### 1. A ficha do candidato quebrava (erro 500 em produção)

Ao abrir o perfil de um candidato, a página podia **quebrar e não carregar**. Acontecia quando uma formação marcada como **concluída** (ou um emprego como **anterior**) estava **sem data de término** — a tela tentava exibir "quando terminou" e travava. Um campo opcional em branco derrubava o perfil inteiro.

### 2. Tempo de duração contraditório e total de experiência inflado

Depois de impedir a quebra, apareceu um segundo problema (apontado na revisão do CodeRabbit): para esse mesmo candidato sem data de saída, o sistema **inventava a duração contando até hoje**. Na prática:

- Ao lado de "saída: *não informada*", mostrava algo como "6 anos de experiência" — duas informações que se contradizem.
- Pior: esse tempo "chutado" era **somado ao total de experiência** do candidato, fazendo-o parecer mais experiente do que realmente é.

> É como dizer: *"Não sei quando você saiu da empresa... mas você ficou exatamente 6 anos lá."*

A análise mostrou que esse mesmo cálculo errado existia em **três lugares** (experiência por item, total de experiência e formação) — a revisão automática só havia apontado um. Todos foram corrigidos.

## ✅ O que foi feito

- **A ficha sempre abre**, mesmo com dados incompletos. Onde faltava a data de término, mostra um traço (**—**); o selo de "Concluído" continua aparecendo.
- **A duração deixou de ser inventada.** Quando não dá para saber quando terminou, o sistema admite que **não sabe** (esconde a duração daquele item) em vez de contar até hoje.
- **O total de experiência ficou honesto.** Empregos sem data de término deixaram de ser somados até hoje — não inflam mais o número geral.
- Vale igualmente para **Formação** e **Experiência profissional**.

## 🧪 Como garantimos que não volta a acontecer

Foram criados **testes automatizados** que recriam exatamente esses cenários (formação concluída e emprego anterior, ambos sem data de término) e verificam que: a tela abre sem erro, a duração não é inventada e o total de experiência não é inflado. Se alguém reintroduzir o problema, os testes acusam antes de chegar em produção.

---

<details>
<summary>🔧 Resumo técnico (para revisão)</summary>

**Causa-raiz:** o cálculo de duração caía no fallback `end_date ?? now()`, assumindo "até hoje" para registros passados/concluídos sem `end_date` (estado válido — o parser de currículo por IA permite `null`). A primeira correção tratou apenas a exibição da data (`?->format() ?? '—'`); restava a semântica da duração, duplicada em 3 pontos.

**Mudanças:**

| Arquivo | Mudança |
|---|---|
| `WorkExperience` / `Education` | novo `durationInMonths(): ?int` — fonte única da regra; retorna `null` quando o período é imensurável (passado/concluído sem `end_date`) |
| `Candidate::getExperienceDuration()` | passa a retornar `?string` (delega ao model) |
| `Candidate::calculateTotalExperienceMonths()` | exclui itens imensuráveis (`durationInMonths() ?? 0`) em vez de contá-los até hoje |
| `education.blade.php` / `work-experience.blade.php` | datas com `?->format() ?? '—'`; duração desconhecida é ocultada |
| PHPDoc de `end_date` (ambos os models) | `Carbon` → `Carbon\|null`, refletindo a nulabilidade real (Larastan/IDE passam a alertar) |

**Testes:** regressão em `WorkExperienceTest`, `EducationTest` e `CandidateTest` (duração nula por item; total exclui o imensurável — falhava com `72`, agora `12`), além dos testes de renderização das abas (`assertOk()` no estado nulo). Suítes: candidates 69/69, aplicação do painel 63/63.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed education and work-experience date displays to safely handle missing end dates and show a placeholder when appropriate.
  * Updated duration display so unmeasurable durations are omitted instead of showing incorrect values; total experience now excludes those entries.

* **Refactor**
  * Duration calculations consolidated to produce null for unmeasurable records (improves display consistency).

* **Tests**
  * Added feature tests covering education/work-experience date and duration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->