### PR TITLE
fix: exige responsável ao criar departamento na criação de vaga

### DIFF
--- a/app-modules/panel-organization/src/Filament/Resources/Recruitment/JobRequisitions/Schemas/JobRequisitionForm.php
+++ b/app-modules/panel-organization/src/Filament/Resources/Recruitment/JobRequisitions/Schemas/JobRequisitionForm.php
@@ -125,6 +125,7 @@ class JobRequisitionForm
                                                             })
                                                             ->orderBy('name'),
                                                     )
+                                                    ->required()
                                                     ->searchable()
                                                     ->preload(),
                                                 Hidden::make('team_id')

--- a/app-modules/panel-organization/tests/Feature/JobRequisition/CreateJobRequisitionTest.php
+++ b/app-modules/panel-organization/tests/Feature/JobRequisition/CreateJobRequisitionTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Enums\FilamentPanel;
+use Filament\Actions\Testing\TestAction;
 use He4rt\Organization\Filament\Resources\Recruitment\JobRequisitions\Pages\CreateJobRequisition;
 use He4rt\Recruitment\Requisitions\Enums\EmploymentTypeEnum;
 use He4rt\Recruitment\Requisitions\Enums\ExperienceLevelEnum;
@@ -18,6 +19,7 @@ use Livewire\Livewire;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\assertDatabaseHas;
+use function Pest\Laravel\assertDatabaseMissing;
 
 beforeEach(function (): void {
     filament()->setCurrentPanel(FilamentPanel::Organization->value);
@@ -118,6 +120,46 @@ it('shows validation errors for required fields when submitting without data', f
     Livewire::test(CreateJobRequisition::class)
         ->call('create')
         ->assertHasFormErrors(['post.title', 'post.summary', 'department_id', 'recruiter_id']);
+});
+
+it('requires a head user when creating a department inline from the requisition form', function (): void {
+    // Reproduz o erro de produção: o head_user_id da tabela departments é NOT NULL,
+    // mas o createOptionForm inline não exigia o campo, gerando QueryException no INSERT.
+    $this->recruiter->user->givePermissionTo('create_departments');
+
+    Livewire::test(CreateJobRequisition::class)
+        ->callAction(
+            TestAction::make('createOption')->schemaComponent('department_id'),
+            data: [
+                'name' => 'Administrativo',
+                'description' => 'Setor administrativo',
+                // head_user_id intencionalmente omitido
+            ],
+        )
+        ->assertHasFormErrors(['head_user_id' => 'required']);
+
+    assertDatabaseMissing(Department::class, ['name' => 'Administrativo']);
+});
+
+it('creates a department inline when a head user is provided', function (): void {
+    $this->recruiter->user->givePermissionTo('create_departments');
+
+    Livewire::test(CreateJobRequisition::class)
+        ->callAction(
+            TestAction::make('createOption')->schemaComponent('department_id'),
+            data: [
+                'name' => 'Administrativo',
+                'description' => 'Setor administrativo',
+                'head_user_id' => $this->recruiter->user->getKey(),
+            ],
+        )
+        ->assertHasNoFormErrors();
+
+    assertDatabaseHas(Department::class, [
+        'name' => 'Administrativo',
+        'team_id' => $this->team->getKey(),
+        'head_user_id' => $this->recruiter->user->getKey(),
+    ]);
 });
 
 it('requires employment_type and work_schedule when creating', function (): void {


### PR DESCRIPTION
## O que estava acontecendo

Ao criar uma vaga, é possível cadastrar um departamento novo ali mesmo, pelo botão "+" do campo **Departamento**. Quando a pessoa preenchia o nome e a descrição, mas **não escolhia o responsável (head) do departamento**, o sistema quebrava e mostrava uma tela de erro — em vez de avisar que faltava preencher um campo.

## Por que acontecia

Todo departamento precisa, obrigatoriamente, de um responsável. Esse formulário rápido de criação não estava marcando o campo "Responsável" como obrigatório. Resultado: deixava prosseguir sem ele e o cadastro estourava na hora de salvar.

## O que foi feito

- O campo **"Responsável"** passou a ser **obrigatório** nesse formulário rápido — do mesmo jeito que já é no cadastro completo de departamentos.
- Agora, se a pessoa esquecer de preencher, aparece um **aviso amigável** pedindo para selecionar o responsável, sem tela de erro.
- Foram adicionados **testes automatizados** que garantem o comportamento: avisa quando falta o responsável e cria o departamento normalmente quando ele é informado.

## Impacto

- **Nenhum dado** foi perdido ou corrompido: o erro acontecia **antes** de salvar, então não há nada para corrigir no banco.
- Correção pequena e focada, sem afetar outras partes do sistema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The head user field is now properly enforced as required in the job requisition form.

* **Tests**
  * Added validation tests to ensure form submission fails when required fields are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->