### PR TITLE
Renomeia rótulo terminal do candidato para "Reprovado"

### DIFF
--- a/app-modules/panel-app/tests/Feature/Filament/Applications/ViewApplicationTest.php
+++ b/app-modules/panel-app/tests/Feature/Filament/Applications/ViewApplicationTest.php
@@ -85,7 +85,7 @@ it('shows neutral title and rejection details for rejected application', functio
 
     livewire(ViewApplication::class, ['record' => $application->getKey()])
         ->assertOk()
-        ->assertSee('Application Not Progressed')
+        ->assertSee('Not Approved')
         ->assertDontSee('Selection Process Stages')
         ->assertSee('Rejection Reason')
         ->assertSee($application->rejection_reason_category->getLabel());

--- a/app-modules/panel-organization/lang/en/view.php
+++ b/app-modules/panel-organization/lang/en/view.php
@@ -67,7 +67,7 @@ return [
         'active_since' => 'Active since :date',
         'hired' => 'Hired',
         'hired_on' => 'Hired on :date',
-        'rejected_title' => 'Application Not Progressed',
+        'rejected_title' => 'Not Approved',
         'rejected_reason' => 'Rejection Reason',
         'rejected_details' => 'Feedback',
         'rejected_screening_message' => 'Please note that, after evaluation, your application will not proceed to the next stages of the selection process.',

--- a/app-modules/panel-organization/lang/pt_BR/view.php
+++ b/app-modules/panel-organization/lang/pt_BR/view.php
@@ -67,7 +67,7 @@ return [
         'active_since' => 'Ativo desde :date',
         'hired' => 'Contratado',
         'hired_on' => 'Contratado em :date',
-        'rejected_title' => 'Candidatura Não Aprovada',
+        'rejected_title' => 'Reprovado',
         'rejected_reason' => 'Motivo da Reprovação',
         'rejected_details' => 'Feedback',
         'rejected_screening_message' => 'Informamos que, após avaliação, sua candidatura não seguirá para as próximas etapas do processo seletivo.',


### PR DESCRIPTION
## Problema

Recomendação do RH após apresentação das melhorias da plataforma: o rótulo terminal exibido ao **candidato rejeitado** deve ser mais direto. Antes mostrava "Candidatura Não Aprovada" (pt_BR) / "Application Not Progressed" (en).

## Solução

Troca o valor da chave de tradução `panel-organization::view.pipeline.rejected_title`:

- **pt_BR:** `Reprovado`
- **en:** `Not Approved`

Essa chave é **compartilhada** por duas telas do candidato — o card do dashboard (`user-latest-applications`) e o sidebar de detalhe da candidatura (`pipeline-progress`, título montado via `$terminalKey . '_title'`) — então ambas passam a exibir o novo texto, de forma consistente. O painel do recrutador **não** é afetado (usa outra view). Nada de comportamento/persistência muda: é só a camada de apresentação.

> Observação: isso reverte parcialmente a neutralização do #194 (que havia abrandado o "Rejeitado" cru), por decisão do RH.

## Testes

- `ViewApplicationTest` — atualizado o literal de `Application Not Progressed` para `Not Approved`.
- `UserLatestApplicationsTest` — assertava via chave de tradução, pega o novo valor automaticamente.
- Suíte afetada verde: **35 testes**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Updates

* Updated rejection status labels displayed in the application pipeline for improved clarity. The "Application Not Progressed" label now displays as "Not Approved" in English and "Candidatura Não Aprovada" now displays as "Reprovado" in Portuguese Brazilian versions to better reflect application decision outcomes.

* **Tests**
  * Updated validation tests to reflect the new rejection status labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->