### PR TITLE
Mostra apenas vagas publicadas no filtro de candidaturas

### DIFF
--- a/app-modules/panel-organization/src/Filament/Resources/Recruitment/Applications/Tables/ApplicationsTable.php
+++ b/app-modules/panel-organization/src/Filament/Resources/Recruitment/Applications/Tables/ApplicationsTable.php
@@ -13,6 +13,7 @@ use Filament\Tables\Table;
 use He4rt\Applications\Enums\ApplicationStatusEnum;
 use He4rt\Applications\Enums\CandidateSourceEnum;
 use He4rt\Applications\Models\Application;
+use He4rt\Recruitment\Requisitions\Enums\RequisitionStatusEnum;
 use Illuminate\Database\Eloquent\Builder;
 
 class ApplicationsTable
@@ -108,7 +109,7 @@ class ApplicationsTable
                     ->options(CandidateSourceEnum::class),
                 SelectFilter::make('requisition')
                     ->label(__('applications::filament.filters.requisition'))
-                    ->relationship('requisition', 'id', fn ($query) => $query->with('post'))
+                    ->relationship('requisition', 'id', fn ($query) => $query->with('post')->where('status', RequisitionStatusEnum::Published))
                     ->getOptionLabelFromRecordUsing(fn ($record) => $record->post->title ?? __('panel-organization::filament.group.job_no_title'))
                     ->preload(),
             ])

--- a/app-modules/panel-organization/tests/Feature/Filament/Application/RequisitionFilterPublishedOnlyTest.php
+++ b/app-modules/panel-organization/tests/Feature/Filament/Application/RequisitionFilterPublishedOnlyTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\FilamentPanel;
+use He4rt\Organization\Filament\Resources\Recruitment\Applications\Pages\ListApplications;
+use He4rt\Permissions\Roles;
+use He4rt\Recruitment\Requisitions\Enums\RequisitionStatusEnum;
+use He4rt\Recruitment\Requisitions\Models\JobPosting;
+use He4rt\Recruitment\Requisitions\Models\JobRequisition;
+use He4rt\Recruitment\Staff\Recruiter\Recruiter;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    $this->recruiter = Recruiter::factory()->create();
+    $this->recruiter->user->assignRole(Roles::SuperAdmin->value);
+    actingAs($this->recruiter->user);
+
+    $this->team = $this->recruiter->team;
+
+    filament()->setCurrentPanel(FilamentPanel::Organization->value);
+    filament()->setTenant($this->team);
+});
+
+function makeRequisitionWithTitle(string $teamId, RequisitionStatusEnum $status, string $title): JobRequisition
+{
+    $requisition = JobRequisition::factory()->create([
+        'team_id' => $teamId,
+        'status' => $status,
+    ]);
+
+    JobPosting::factory()->for($requisition, 'jobRequisition')->create(['title' => $title]);
+
+    return $requisition;
+}
+
+it('lists a published requisition as an option in the requisition filter', function (): void {
+    makeRequisitionWithTitle($this->team->id, RequisitionStatusEnum::Published, 'PUBLISHED_VACANCY_OPTION');
+
+    livewire(ListApplications::class)
+        ->assertSuccessful()
+        ->assertSee('PUBLISHED_VACANCY_OPTION');
+});
+
+it('does not list non-published requisitions as options in the requisition filter', function (RequisitionStatusEnum $status, string $title): void {
+    makeRequisitionWithTitle($this->team->id, RequisitionStatusEnum::Published, 'PUBLISHED_VACANCY_OPTION');
+    makeRequisitionWithTitle($this->team->id, $status, $title);
+
+    livewire(ListApplications::class)
+        ->assertSuccessful()
+        ->assertSee('PUBLISHED_VACANCY_OPTION')
+        ->assertDontSee($title);
+})->with([
+    'draft' => [RequisitionStatusEnum::Draft, 'DRAFT_VACANCY_OPTION'],
+    'pending approval' => [RequisitionStatusEnum::PendingApproval, 'PENDING_VACANCY_OPTION'],
+    'approved' => [RequisitionStatusEnum::Approved, 'APPROVED_VACANCY_OPTION'],
+    'on hold' => [RequisitionStatusEnum::OnHold, 'ONHOLD_VACANCY_OPTION'],
+    'closed' => [RequisitionStatusEnum::Closed, 'CLOSED_VACANCY_OPTION'],
+    'cancelled' => [RequisitionStatusEnum::Cancelled, 'CANCELLED_VACANCY_OPTION'],
+]);


### PR DESCRIPTION
## O que muda

Na tela de **Candidaturas** (painel da organização), o filtro de **vaga** listava **todas** as vagas — inclusive rascunhos e vagas que nunca chegaram a ser publicadas. Como só é possível se candidatar a uma vaga publicada, essas outras opções apenas poluíam o filtro e não ajudavam em nada na hora de buscar.

Agora o filtro mostra **somente as vagas publicadas**, deixando a lista mais curta, limpa e útil para quem acompanha as candidaturas.

A mudança foi coberta por testes automáticos que garantem que vagas em rascunho, em aprovação, aprovadas, em espera, fechadas ou canceladas não apareçam mais como opção no filtro.