### PR TITLE
Impede mover candidato para etapa inválida (trava no domínio)

### DIFF
--- a/app-modules/applications/src/Exceptions/InvalidTransitionException.php
+++ b/app-modules/applications/src/Exceptions/InvalidTransitionException.php
@@ -18,4 +18,9 @@ final class InvalidTransitionException extends Exception
     {
         return new self(sprintf('Invalid target status: %s', $status), 400);
     }
+
+    public static function invalidTargetStage(string $stageId): self
+    {
+        return new self(sprintf('Invalid target stage: %s', $stageId), 400);
+    }
 }

--- a/app-modules/applications/src/Services/Transitions/InProgressTransition.php
+++ b/app-modules/applications/src/Services/Transitions/InProgressTransition.php
@@ -9,6 +9,7 @@ use He4rt\Applications\Enums\RejectionReasonCategoryEnum;
 use He4rt\Applications\Exceptions\InvalidTransitionException;
 use He4rt\Applications\Exceptions\MissingTransitionDataException;
 use He4rt\Recruitment\Stages\Enums\StageTypeEnum;
+use He4rt\Recruitment\Stages\Models\Stage;
 
 final class InProgressTransition extends AbstractApplicationTransition
 {
@@ -94,9 +95,26 @@ final class InProgressTransition extends AbstractApplicationTransition
     private function resolveTargetStage(TransitionData $data): ?string
     {
         return match (true) {
-            $data->toStageId !== null => $data->toStageId,
+            $data->toStageId !== null => $this->validateExplicitStage($data->toStageId)->getKey(),
             $data->advanceStage === true => $this->application->getNextStage()?->getKey(),
             default => null,
         };
+    }
+
+    private function validateExplicitStage(string $stageId): Stage
+    {
+        $currentOrder = $this->application->currentStage?->display_order ?? -1; // @phpstan-ignore nullsafe.neverNull
+
+        $stage = ($this->application->requisition?->stages ?? collect()) // @phpstan-ignore nullsafe.neverNull
+            ->firstWhere('id', $stageId);
+
+        throw_unless(
+            $stage instanceof Stage
+                && $stage->active
+                && $stage->display_order > $currentOrder,
+            InvalidTransitionException::invalidTargetStage($stageId),
+        );
+
+        return $stage;
     }
 }

--- a/app-modules/applications/tests/Feature/Transitions/AbstractTransitionTest.php
+++ b/app-modules/applications/tests/Feature/Transitions/AbstractTransitionTest.php
@@ -99,9 +99,12 @@ describe('AbstractApplicationTransition::handle()', function (): void {
         $application = Application::factory()->create([
             'status' => ApplicationStatusEnum::InProgress,
         ]);
+        $application->currentStage->update(['display_order' => 1, 'active' => true]);
 
         $newStage = Stage::factory()->create([
             'job_requisition_id' => $application->requisition_id,
+            'display_order' => 10,
+            'active' => true,
         ]);
 
         $data = TransitionData::fromArray([

--- a/app-modules/applications/tests/Feature/Transitions/InProgressTransitionTest.php
+++ b/app-modules/applications/tests/Feature/Transitions/InProgressTransitionTest.php
@@ -35,9 +35,18 @@ describe('InProgressTransition', function (): void {
     it('InProgress → InProgress via to_stage_id updates current_stage_id', function (): void {
         $user = User::factory()->create();
         $application = Application::factory()->withStatus(ApplicationStatusEnum::InProgress)->create();
+
+        $current = Stage::factory()->create([
+            'job_requisition_id' => $application->requisition_id,
+            'display_order' => 1,
+            'active' => true,
+        ]);
+        $application->update(['current_stage_id' => $current->id]);
+
         $targetStage = Stage::factory()->create([
             'job_requisition_id' => $application->requisition_id,
             'display_order' => 10,
+            'active' => true,
         ]);
 
         $data = TransitionData::fromArray([
@@ -51,6 +60,94 @@ describe('InProgressTransition', function (): void {
 
         expect($application->status)->toBe(ApplicationStatusEnum::InProgress)
             ->and($application->current_stage_id)->toBe($targetStage->id);
+    });
+
+    it('rejects a move to an earlier or same-order stage and keeps current_stage_id', function (int $targetOrder): void {
+        $user = User::factory()->create();
+        $application = Application::factory()->withStatus(ApplicationStatusEnum::InProgress)->create();
+
+        $current = Stage::factory()->create([
+            'job_requisition_id' => $application->requisition_id,
+            'display_order' => 5,
+            'active' => true,
+        ]);
+        $application->update(['current_stage_id' => $current->id]);
+
+        $target = Stage::factory()->create([
+            'job_requisition_id' => $application->requisition_id,
+            'display_order' => $targetOrder,
+            'active' => true,
+        ]);
+
+        $data = TransitionData::fromArray([
+            'to_status' => ApplicationStatusEnum::InProgress,
+            'to_stage_id' => $target->id,
+        ], $user->id);
+
+        expect(fn () => $application->current_step->handle($data))
+            ->toThrow(InvalidTransitionException::class);
+
+        expect($application->fresh()->current_stage_id)->toBe($current->id);
+    })->with([
+        'earlier stage' => 3,
+        'same-order stage' => 5,
+    ]);
+
+    it('rejects a move to an inactive stage and keeps current_stage_id', function (): void {
+        $user = User::factory()->create();
+        $application = Application::factory()->withStatus(ApplicationStatusEnum::InProgress)->create();
+
+        $current = Stage::factory()->create([
+            'job_requisition_id' => $application->requisition_id,
+            'display_order' => 5,
+            'active' => true,
+        ]);
+        $application->update(['current_stage_id' => $current->id]);
+
+        $inactive = Stage::factory()->create([
+            'job_requisition_id' => $application->requisition_id,
+            'display_order' => 9,
+            'active' => false,
+        ]);
+
+        $data = TransitionData::fromArray([
+            'to_status' => ApplicationStatusEnum::InProgress,
+            'to_stage_id' => $inactive->id,
+        ], $user->id);
+
+        expect(fn () => $application->current_step->handle($data))
+            ->toThrow(InvalidTransitionException::class);
+
+        expect($application->fresh()->current_stage_id)->toBe($current->id);
+    });
+
+    it('rejects a move to a stage from another requisition and keeps current_stage_id', function (): void {
+        $user = User::factory()->create();
+        $application = Application::factory()->withStatus(ApplicationStatusEnum::InProgress)->create();
+
+        $current = Stage::factory()->create([
+            'job_requisition_id' => $application->requisition_id,
+            'display_order' => 5,
+            'active' => true,
+        ]);
+        $application->update(['current_stage_id' => $current->id]);
+
+        // Belongs to a brand-new requisition (own JobRequisition::factory()), so it is
+        // forward and active but must still be refused as cross-requisition.
+        $foreignStage = Stage::factory()->create([
+            'display_order' => 9,
+            'active' => true,
+        ]);
+
+        $data = TransitionData::fromArray([
+            'to_status' => ApplicationStatusEnum::InProgress,
+            'to_stage_id' => $foreignStage->id,
+        ], $user->id);
+
+        expect(fn () => $application->current_step->handle($data))
+            ->toThrow(InvalidTransitionException::class);
+
+        expect($application->fresh()->current_stage_id)->toBe($current->id);
     });
 
     it('InProgress → InProgress via advance_stage moves to next stage', function (): void {


### PR DESCRIPTION
## O que é

O processo seletivo de uma vaga funciona como um **tabuleiro com etapas em sequência** (Triagem → Entrevista → Desafio → Final → Oferta). O candidato avança por essas casas, e a regra é: só anda **para frente**, e só pode parar em etapas que existem naquela vaga e que estão ativas.

## Qual era o problema

Essa regra estava sendo cobrada **apenas na tela** do RH: o menu de mover candidato já mostrava só as opções válidas. Mas a tela e o "motor" que de fato grava a mudança são coisas separadas — e o motor **não conferia nada**, aceitando qualquer ordem que chegasse.

> É a diferença entre uma **placa de "proibido entrar"** e uma **porta trancada**. Tínhamos a placa, mas a porta estava destrancada.

Na prática, isso deixava o motor aceitar três movimentos que nunca deveriam acontecer:

1. **Voltar para trás** — mandar o candidato de uma etapa avançada de volta para uma anterior;
2. **Cair numa etapa desativada** — mover para uma etapa que a empresa já tinha desligado daquele processo;
3. **Pular para outra vaga** — mover o candidato para uma etapa que pertence a uma vaga **diferente**.

Nada disso era possível clicando normalmente na tela, mas qualquer outro caminho (uma automação, um teste, uma requisição manipulada) conseguia fazer — e o sistema gravava sem reclamar, deixando o histórico da candidatura inconsistente.

## O que mudou

A regra foi movida para **dentro do motor**. Agora, antes de gravar qualquer mudança de etapa, o próprio sistema confere: *a etapa é da mesma vaga? está ativa? está à frente de onde o candidato está?* Se qualquer resposta for "não", ele **recusa** e nada é alterado — o candidato permanece exatamente onde estava.

A vantagem é que a trava passa a valer para **todos os caminhos de uma vez** (tela do RH, Kanban, automações e qualquer funcionalidade futura), não só para a tela atual. O comportamento visível para o usuário continua igual.

## Verificação

- Testes de regressão cobrindo os três movimentos inválidos (para trás/mesma ordem, etapa inativa, outra vaga);
- Suíte completa do projeto verde (1091 testes), além de Pint e análise estática sem apontamentos.

Closes #162


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for application stage transitions to prevent moving to inactive stages, earlier stages, or stages from different requisitions. Invalid transitions now return appropriate error messages.

* **Tests**
  * Enhanced test coverage for stage transition validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->