### PR TITLE
fix: corrige problemas no aviso de candidatura recebida (sininho, idioma e robustez)

### DIFF
--- a/app-modules/applications/lang/en/filament.php
+++ b/app-modules/applications/lang/en/filament.php
@@ -139,6 +139,7 @@ return [
             'greeting' => 'Hi :name,',
             'line' => 'We received your application for :job. You can follow its progress in your panel.',
             'action' => 'View application',
+            'job_fallback' => 'the position',
         ],
     ],
 

--- a/app-modules/applications/lang/pt_BR/filament.php
+++ b/app-modules/applications/lang/pt_BR/filament.php
@@ -137,6 +137,7 @@ return [
             'greeting' => 'Olá :name,',
             'line' => 'Recebemos sua candidatura para :job. Você pode acompanhar o andamento no seu painel.',
             'action' => 'Ver candidatura',
+            'job_fallback' => 'a vaga',
         ],
     ],
 

--- a/app-modules/applications/src/Mail/ApplicationReceivedMail.php
+++ b/app-modules/applications/src/Mail/ApplicationReceivedMail.php
@@ -23,7 +23,7 @@ class ApplicationReceivedMail extends Mailable implements ShouldQueue
     {
         return new Envelope(
             subject: __('applications::filament.emails.application_received.subject', [
-                'job' => $this->application->requisition->post->title,
+                'job' => $this->jobTitle(),
             ]),
         );
     }
@@ -34,7 +34,7 @@ class ApplicationReceivedMail extends Mailable implements ShouldQueue
             markdown: 'applications::emails.application-received',
             with: [
                 'candidateName' => $this->application->candidate->user->name,
-                'jobTitle' => $this->application->requisition->post->title,
+                'jobTitle' => $this->jobTitle(),
                 // Rota nomeada (string) em vez de panel-app::ApplicationResource::getUrl()
                 // para não criar dependência reversa applications -> panel-app.
                 'url' => route('filament.app.resources.applications.view', [
@@ -42,5 +42,15 @@ class ApplicationReceivedMail extends Mailable implements ShouldQueue
                 ]),
             ],
         );
+    }
+
+    /**
+     * Job title for the message, falling back to a generic label when the
+     * requisition has no (or a soft-deleted) posting.
+     */
+    private function jobTitle(): string
+    {
+        return $this->application->requisition->postTitle()
+            ?? __('applications::filament.emails.application_received.job_fallback');
     }
 }

--- a/app-modules/applications/src/Notifications/ApplicationReceivedNotification.php
+++ b/app-modules/applications/src/Notifications/ApplicationReceivedNotification.php
@@ -41,7 +41,8 @@ final class ApplicationReceivedNotification extends Notification implements Shou
         return FilamentNotification::make()
             ->title(__('applications::filament.notifications.application_received.title'))
             ->body(__('applications::filament.notifications.application_received.body', [
-                'job' => $this->application->requisition->post->title,
+                'job' => $this->application->requisition->postTitle()
+                    ?? __('applications::filament.emails.application_received.job_fallback'),
             ]))
             ->icon(Heroicon::OutlinedCheckCircle)
             ->actions([

--- a/app-modules/applications/tests/Feature/Mail/ApplicationReceivedMailTest.php
+++ b/app-modules/applications/tests/Feature/Mail/ApplicationReceivedMailTest.php
@@ -18,3 +18,17 @@ it('builds the application received mail with subject and job title', function (
     $mailable->assertHasSubject(__('applications::filament.emails.application_received.subject', ['job' => $jobTitle]));
     $mailable->assertSeeInHtml($jobTitle);
 });
+
+it('falls back to a generic job title when the posting is missing', function (): void {
+    $application = Application::factory()->create();
+    $application->load('requisition.post');
+
+    expect($application->requisition->post)->toBeNull();
+
+    $fallback = __('applications::filament.emails.application_received.job_fallback');
+
+    $mailable = new ApplicationReceivedMail($application);
+
+    $mailable->assertHasSubject(__('applications::filament.emails.application_received.subject', ['job' => $fallback]));
+    $mailable->assertSeeInHtml($fallback);
+});

--- a/app-modules/applications/tests/Feature/Notifications/ApplicationReceivedNotificationContentTest.php
+++ b/app-modules/applications/tests/Feature/Notifications/ApplicationReceivedNotificationContentTest.php
@@ -23,5 +23,20 @@ it('targets mail and database channels and is queued', function (): void {
     $database = $notification->toDatabase($user);
 
     expect($database)->toBeArray()
-        ->and(json_encode($database))->toContain($application->requisition->post->title);
+        ->and($database['body'])->toContain($application->requisition->post->title);
+});
+
+it('falls back to a generic job title in the database payload when the posting is missing', function (): void {
+    $application = Application::factory()->create();
+    $application->load('requisition.post');
+
+    $user = $application->candidate->user;
+
+    expect($application->requisition->post)->toBeNull();
+
+    $fallback = __('applications::filament.emails.application_received.job_fallback');
+
+    $database = new ApplicationReceivedNotification($application)->toDatabase($user);
+
+    expect($database['body'])->toContain($fallback);
 });

--- a/app-modules/panel-app/tests/Feature/Filament/AppPanelTest.php
+++ b/app-modules/panel-app/tests/Feature/Filament/AppPanelTest.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\FilamentPanel;
+
+it('enables database notifications on the candidate (app) panel so the bell renders', function (): void {
+    expect(filament()->getPanel(FilamentPanel::App->value)->hasDatabaseNotifications())->toBeTrue();
+});

--- a/app-modules/recruitment/src/Requisitions/Models/JobRequisition.php
+++ b/app-modules/recruitment/src/Requisitions/Models/JobRequisition.php
@@ -105,6 +105,13 @@ class JobRequisition extends BaseModel implements HasActivityLogTitle
         return $this->hasOne(JobPosting::class, 'job_requisition_id');
     }
 
+    public function postTitle(): ?string
+    {
+        return JobPosting::query()
+            ->where('job_requisition_id', $this->getKey())
+            ->first()?->title;
+    }
+
     /**
      * @return HasMany<JobRequisitionItem, $this>
      */

--- a/app-modules/users/src/User.php
+++ b/app-modules/users/src/User.php
@@ -18,6 +18,7 @@ use He4rt\Recruitment\Stages\Concerns\InteractsWithInterviewStages;
 use He4rt\Teams\Concerns\InteractsWithTenants;
 use He4rt\Teams\Team;
 use He4rt\Users\Database\Factories\UserFactory;
+use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Attributes\UseFactory;
 use Illuminate\Database\Eloquent\Attributes\UsePolicy;
@@ -51,7 +52,7 @@ use Spatie\Permission\Traits\HasRoles;
 #[UsePolicy(UserPolicy::class)]
 #[UseFactory(UserFactory::class)]
 #[ObservedBy(UserObserver::class)]
-final class User extends Authenticatable implements Commenter, FilamentUser, HasAvatar, HasMedia, HasTenants
+final class User extends Authenticatable implements Commenter, FilamentUser, HasAvatar, HasLocalePreference, HasMedia, HasTenants
 {
     /** @use HasFactory<UserFactory> */
     use HasFactory;
@@ -121,6 +122,11 @@ final class User extends Authenticatable implements Commenter, FilamentUser, Has
     public function candidate(): HasOne
     {
         return $this->hasOne(Candidate::class, 'user_id');
+    }
+
+    public function preferredLocale(): ?string
+    {
+        return $this->candidate?->preferred_language;
     }
 
     /**

--- a/app-modules/users/tests/Feature/UserPreferredLocaleTest.php
+++ b/app-modules/users/tests/Feature/UserPreferredLocaleTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Users\User;
+use Illuminate\Contracts\Translation\HasLocalePreference;
+
+it('exposes the candidate preferred language as the locale preference', function (): void {
+    $user = User::factory()->create();
+    $user->candidate()->update(['preferred_language' => 'pt_BR']);
+
+    expect($user->fresh())->toBeInstanceOf(HasLocalePreference::class)
+        ->and($user->fresh()->preferredLocale())->toBe('pt_BR');
+});
+
+it('has no locale preference when the user has no candidate', function (): void {
+    $user = User::factory()->create();
+    $user->candidate()->delete();
+
+    expect($user->fresh()->preferredLocale())->toBeNull();
+});

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -54,6 +54,7 @@ class AppPanelProvider extends PanelProvider
             ->brandLogo(fn () => view('partials.logo-compact'))
             ->favicon(asset('favicon.ico'))
             ->maxContentWidth(Width::ScreenTwoExtraLarge)
+            ->databaseNotifications()
             ->path($this->panelEnum->getPath())
             ->colors([
                 'primary' => Color::Gray,


### PR DESCRIPTION
## O que muda

Depois que entregamos o aviso de "candidatura recebida", revisamos esse fluxo de ponta a ponta e encontramos três pontos que precisavam de ajuste. Este PR corrige os três.

### 1. O aviso no painel (o "sininho") agora aparece

A notificação dentro do painel do candidato estava sendo registrada, mas não era exibida — o painel do candidato não tinha esse recurso ativado (só os painéis internos tinham). Agora está ativado: além do e-mail, o candidato vê o aviso no sininho do próprio painel.

### 2. O aviso sai no idioma do candidato

O e-mail e a notificação estavam saindo sempre em inglês, independentemente do idioma escolhido pela pessoa. Isso acontecia porque o envio é processado em segundo plano, fora da navegação, e nesse momento a informação de idioma se perdia. Agora o sistema usa o idioma que o candidato definiu no perfil. Quem nunca definiu continua recebendo no idioma padrão.

### 3. O aviso não quebra mais quando a vaga fica sem anúncio

Se o anúncio de uma vaga fosse removido entre a candidatura e o envio do aviso, o processo quebrava e o aviso não era entregue. Agora, nesse caso raro, o aviso usa um texto genérico ("a vaga") e é entregue normalmente, sem falhar.

## O que continua igual

Nada muda no dia a dia de quem já usava. São melhorias de robustez e de experiência no aviso de candidatura recebida; os avisos, a navegação e as regras continuam os mesmos.

## Garantias

Tudo está coberto por testes automatizados, e a verificação de estilo e a análise estática passaram.

## Relacionado

Continuação do trabalho de notificação ao candidato (parte do épico de política de comunicação com o candidato, #191).
