### PR TITLE
refactor(applications): renomeia state machine de Transition para State

### DIFF
--- a/app-modules/applications/README.md
+++ b/app-modules/applications/README.md
@@ -115,7 +115,7 @@ Withdrawn     → Candidate withdrew
   `isTerminal()`: the _positive_ finals (`OfferAccepted`/`Hired`) also forbid a
   rejection without being a terminal stop. Once an offer is extended the negative
   path is a _declined_ offer, not a rejection — the state machine
-  (`OfferExtendedTransition`) only models `OfferAccepted`/`OfferDeclined`/`Withdrawn`,
+  (`OfferExtendedApplicationState`) only models `OfferAccepted`/`OfferDeclined`/`Withdrawn`,
   so this guard is aligned to it. Drives the disabled state of the reject action.
 
 ### CandidateSourceEnum

--- a/app-modules/applications/src/Actions/RejectApplicationAction.php
+++ b/app-modules/applications/src/Actions/RejectApplicationAction.php
@@ -7,7 +7,7 @@ namespace He4rt\Applications\Actions;
 use He4rt\Applications\Enums\ApplicationStatusEnum;
 use He4rt\Applications\Enums\RejectionReasonCategoryEnum;
 use He4rt\Applications\Models\Application;
-use He4rt\Applications\Services\Transitions\TransitionData;
+use He4rt\Applications\States\TransitionData;
 
 final class RejectApplicationAction
 {
@@ -15,7 +15,7 @@ final class RejectApplicationAction
     {
         $application = Application::query()->findOrFail($applicationId);
 
-        $application->current_step->handle(TransitionData::fromArray([
+        $application->current_state->handle(TransitionData::fromArray([
             'to_status' => ApplicationStatusEnum::Rejected,
             'rejection_reason_category' => $reason,
             'rejection_reason_details' => $details,

--- a/app-modules/applications/src/Enums/ApplicationStatusEnum.php
+++ b/app-modules/applications/src/Enums/ApplicationStatusEnum.php
@@ -11,16 +11,16 @@ use Filament\Support\Contracts\HasIcon;
 use Filament\Support\Contracts\HasLabel;
 use Filament\Support\Icons\Heroicon;
 use He4rt\Applications\Models\Application;
-use He4rt\Applications\Services\Transitions\AbstractApplicationTransition;
-use He4rt\Applications\Services\Transitions\HiredTransition;
-use He4rt\Applications\Services\Transitions\InProgressTransition;
-use He4rt\Applications\Services\Transitions\InReviewTransition;
-use He4rt\Applications\Services\Transitions\NewTransition;
-use He4rt\Applications\Services\Transitions\OfferAcceptedTransition;
-use He4rt\Applications\Services\Transitions\OfferDeclinedTransition;
-use He4rt\Applications\Services\Transitions\OfferExtendedTransition;
-use He4rt\Applications\Services\Transitions\RejectApplicationTransition;
-use He4rt\Applications\Services\Transitions\WithdrawnTransition;
+use He4rt\Applications\States\ApplicationState;
+use He4rt\Applications\States\HiredApplicationState;
+use He4rt\Applications\States\InProgressApplicationState;
+use He4rt\Applications\States\InReviewApplicationState;
+use He4rt\Applications\States\NewApplicationState;
+use He4rt\Applications\States\OfferAcceptedApplicationState;
+use He4rt\Applications\States\OfferDeclinedApplicationState;
+use He4rt\Applications\States\OfferExtendedApplicationState;
+use He4rt\Applications\States\RejectedApplicationState;
+use He4rt\Applications\States\WithdrawnApplicationState;
 
 enum ApplicationStatusEnum: string implements HasColor, HasIcon, HasLabel
 {
@@ -92,7 +92,7 @@ enum ApplicationStatusEnum: string implements HasColor, HasIcon, HasLabel
      * negative outcomes are painted as a terminal stop in the pipeline stepper.
      *
      * Once an offer is extended, the negative path is a declined offer, not a
-     * rejection: the state machine (OfferExtendedTransition) only models
+     * rejection: the state machine (OfferExtendedApplicationState) only models
      * OfferAccepted/OfferDeclined/Withdrawn, so this guard is aligned to it and
      * forbids rejecting an OfferExtended application.
      */
@@ -109,18 +109,18 @@ enum ApplicationStatusEnum: string implements HasColor, HasIcon, HasLabel
         };
     }
 
-    public function getAction(Application $application): AbstractApplicationTransition
+    public function state(Application $application): ApplicationState
     {
         return match ($this) {
-            self::New => new NewTransition($application),
-            self::InReview => new InReviewTransition($application),
-            self::InProgress => new InProgressTransition($application),
-            self::OfferExtended => new OfferExtendedTransition($application),
-            self::OfferAccepted => new OfferAcceptedTransition($application),
-            self::OfferDeclined => new OfferDeclinedTransition($application),
-            self::Hired => new HiredTransition($application),
-            self::Rejected => new RejectApplicationTransition($application),
-            self::Withdrawn => new WithdrawnTransition($application),
+            self::New => new NewApplicationState($application),
+            self::InReview => new InReviewApplicationState($application),
+            self::InProgress => new InProgressApplicationState($application),
+            self::OfferExtended => new OfferExtendedApplicationState($application),
+            self::OfferAccepted => new OfferAcceptedApplicationState($application),
+            self::OfferDeclined => new OfferDeclinedApplicationState($application),
+            self::Hired => new HiredApplicationState($application),
+            self::Rejected => new RejectedApplicationState($application),
+            self::Withdrawn => new WithdrawnApplicationState($application),
         };
     }
 

--- a/app-modules/applications/src/Jobs/RejectScreeningKnockoutJob.php
+++ b/app-modules/applications/src/Jobs/RejectScreeningKnockoutJob.php
@@ -7,7 +7,7 @@ namespace He4rt\Applications\Jobs;
 use He4rt\Applications\Enums\ApplicationStatusEnum;
 use He4rt\Applications\Enums\RejectionReasonCategoryEnum;
 use He4rt\Applications\Models\Application;
-use He4rt\Applications\Services\Transitions\TransitionData;
+use He4rt\Applications\States\TransitionData;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -46,6 +46,6 @@ final class RejectScreeningKnockoutJob implements ShouldQueue
             'notes' => __('screening::messages.knockout_auto_rejected'),
         ]);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
     }
 }

--- a/app-modules/applications/src/Listeners/HandleScreeningKnockoutTransition.php
+++ b/app-modules/applications/src/Listeners/HandleScreeningKnockoutTransition.php
@@ -6,7 +6,7 @@ namespace He4rt\Applications\Listeners;
 
 use He4rt\Applications\Enums\ApplicationStatusEnum;
 use He4rt\Applications\Jobs\RejectScreeningKnockoutJob;
-use He4rt\Applications\Services\Transitions\TransitionData;
+use He4rt\Applications\States\TransitionData;
 use He4rt\Screening\Events\ScreeningEvaluated;
 
 final class HandleScreeningKnockoutTransition
@@ -36,7 +36,7 @@ final class HandleScreeningKnockoutTransition
                 'notes' => __('screening::messages.knockout_auto_advanced'),
             ]);
 
-            $application->current_step->handle($data);
+            $application->current_state->handle($data);
         }
     }
 }

--- a/app-modules/applications/src/Models/Application.php
+++ b/app-modules/applications/src/Models/Application.php
@@ -10,7 +10,7 @@ use He4rt\Applications\Enums\ApplicationStatusEnum;
 use He4rt\Applications\Enums\CandidateSourceEnum;
 use He4rt\Applications\Enums\RejectionReasonCategoryEnum;
 use He4rt\Applications\Policies\ApplicationPolicy;
-use He4rt\Applications\Services\Transitions\AbstractApplicationTransition;
+use He4rt\Applications\States\ApplicationState;
 use He4rt\Candidates\Models\Candidate;
 use He4rt\Feedback\Models\Evaluation;
 use He4rt\Recruitment\Requisitions\Models\JobRequisition;
@@ -48,7 +48,7 @@ use Kirschbaum\Commentions\HasComments;
  * @property Carbon|null $offer_extended_at
  * @property string|null $offer_extended_by
  * @property float|null $offer_amount
- * @property AbstractApplicationTransition $current_step
+ * @property ApplicationState $current_state
  * @property Carbon|null $offer_response_deadline
  * @property Carbon $created_at
  * @property Carbon $updated_at
@@ -136,7 +136,7 @@ class Application extends BaseModel implements Commentable
      * The first active stage of the given type in this requisition (by display_order),
      * or null when the requisition has no stage of that type. Used to mirror the
      * status onto the stage at the funnel ends (offer/hired) — see
-     * AbstractApplicationTransition::advanceToStageType().
+     * ApplicationState::advanceToStageType().
      */
     public function firstStageOfType(StageTypeEnum $type): ?Stage
     {
@@ -214,8 +214,8 @@ class Application extends BaseModel implements Commentable
     /**
      * @phpstan-ignore missingType.generics
      */
-    protected function currentStep(): Attribute
+    protected function currentState(): Attribute
     {
-        return Attribute::make(get: fn () => $this->status->getAction($this));
+        return Attribute::make(get: fn () => $this->status->state($this));
     }
 }

--- a/app-modules/applications/src/States/ApplicationState.php
+++ b/app-modules/applications/src/States/ApplicationState.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace He4rt\Applications\Services\Transitions;
+namespace He4rt\Applications\States;
 
 use He4rt\Applications\Events\ApplicationStatusChanged;
 use He4rt\Applications\Models\Application;
@@ -11,7 +11,7 @@ use He4rt\Recruitment\Stages\Models\Stage;
 use He4rt\Users\User;
 use Illuminate\Support\Facades\DB;
 
-abstract class AbstractApplicationTransition
+abstract class ApplicationState
 {
     public function __construct(public Application $application) {}
 

--- a/app-modules/applications/src/States/HiredApplicationState.php
+++ b/app-modules/applications/src/States/HiredApplicationState.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace He4rt\Applications\Services\Transitions;
+namespace He4rt\Applications\States;
 
 use He4rt\Applications\Enums\ApplicationStatusEnum;
 
-final class HiredTransition extends AbstractApplicationTransition
+final class HiredApplicationState extends ApplicationState
 {
     public function choices(): array
     {

--- a/app-modules/applications/src/States/InProgressApplicationState.php
+++ b/app-modules/applications/src/States/InProgressApplicationState.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace He4rt\Applications\Services\Transitions;
+namespace He4rt\Applications\States;
 
 use He4rt\Applications\Enums\ApplicationStatusEnum;
 use He4rt\Applications\Enums\RejectionReasonCategoryEnum;
@@ -11,7 +11,7 @@ use He4rt\Applications\Exceptions\MissingTransitionDataException;
 use He4rt\Recruitment\Stages\Enums\StageTypeEnum;
 use He4rt\Recruitment\Stages\Models\Stage;
 
-final class InProgressTransition extends AbstractApplicationTransition
+final class InProgressApplicationState extends ApplicationState
 {
     public function choices(): array
     {

--- a/app-modules/applications/src/States/InReviewApplicationState.php
+++ b/app-modules/applications/src/States/InReviewApplicationState.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace He4rt\Applications\Services\Transitions;
+namespace He4rt\Applications\States;
 
 use He4rt\Applications\Enums\ApplicationStatusEnum;
 use He4rt\Applications\Enums\RejectionReasonCategoryEnum;
 use He4rt\Applications\Exceptions\InvalidTransitionException;
 use He4rt\Applications\Exceptions\MissingTransitionDataException;
 
-final class InReviewTransition extends AbstractApplicationTransition
+final class InReviewApplicationState extends ApplicationState
 {
     public function choices(): array
     {

--- a/app-modules/applications/src/States/NewApplicationState.php
+++ b/app-modules/applications/src/States/NewApplicationState.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace He4rt\Applications\Services\Transitions;
+namespace He4rt\Applications\States;
 
 use He4rt\Applications\Enums\ApplicationStatusEnum;
 use He4rt\Applications\Exceptions\InvalidTransitionException;
 use He4rt\Recruitment\Stages\Models\Stage;
 
-final class NewTransition extends AbstractApplicationTransition
+final class NewApplicationState extends ApplicationState
 {
     public function choices(): array
     {

--- a/app-modules/applications/src/States/OfferAcceptedApplicationState.php
+++ b/app-modules/applications/src/States/OfferAcceptedApplicationState.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace He4rt\Applications\Services\Transitions;
+namespace He4rt\Applications\States;
 
 use He4rt\Applications\Enums\ApplicationStatusEnum;
 use He4rt\Applications\Exceptions\InvalidTransitionException;
 use He4rt\Recruitment\Stages\Enums\StageTypeEnum;
 
-final class OfferAcceptedTransition extends AbstractApplicationTransition
+final class OfferAcceptedApplicationState extends ApplicationState
 {
     public function choices(): array
     {

--- a/app-modules/applications/src/States/OfferDeclinedApplicationState.php
+++ b/app-modules/applications/src/States/OfferDeclinedApplicationState.php
@@ -2,18 +2,12 @@
 
 declare(strict_types=1);
 
-namespace He4rt\Applications\Services\Transitions;
+namespace He4rt\Applications\States;
 
 use He4rt\Applications\Enums\ApplicationStatusEnum;
 
-/**
- * Handle candidate-initiated or admin-initiated withdrawals.
- */
-final class WithdrawnTransition extends AbstractApplicationTransition
+final class OfferDeclinedApplicationState extends ApplicationState
 {
-    /**
-     * @return array<string,string|null>
-     */
     public function choices(): array
     {
         return [];
@@ -29,7 +23,7 @@ final class WithdrawnTransition extends AbstractApplicationTransition
     public function processStep(TransitionData $data): void
     {
         $this->application->update([
-            'status' => ApplicationStatusEnum::Withdrawn,
+            'status' => ApplicationStatusEnum::OfferDeclined,
         ]);
     }
 

--- a/app-modules/applications/src/States/OfferExtendedApplicationState.php
+++ b/app-modules/applications/src/States/OfferExtendedApplicationState.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace He4rt\Applications\Services\Transitions;
+namespace He4rt\Applications\States;
 
 use He4rt\Applications\Enums\ApplicationStatusEnum;
 use He4rt\Applications\Exceptions\InvalidTransitionException;
 
-final class OfferExtendedTransition extends AbstractApplicationTransition
+final class OfferExtendedApplicationState extends ApplicationState
 {
     public function choices(): array
     {
@@ -35,7 +35,7 @@ final class OfferExtendedTransition extends AbstractApplicationTransition
      *
      * The offer fields (offer_extended_at, offer_extended_by, offer_amount,
      * offer_response_deadline) are persisted earlier, when the offer is created in
-     * InProgressTransition::processOfferExtension() on the InProgress -> OfferExtended
+     * InProgressApplicationState::processOfferExtension() on the InProgress -> OfferExtended
      * step. This step intentionally updates only the status so it never overwrites
      * those values. Fields are collected in StateTransitionAction and carried by
      * TransitionData.

--- a/app-modules/applications/src/States/RejectedApplicationState.php
+++ b/app-modules/applications/src/States/RejectedApplicationState.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace He4rt\Applications\Services\Transitions;
+namespace He4rt\Applications\States;
 
 use He4rt\Applications\Enums\ApplicationStatusEnum;
 use He4rt\Applications\Enums\RejectionReasonCategoryEnum;
@@ -10,7 +10,7 @@ use He4rt\Applications\Exceptions\MissingTransitionDataException;
 
 use function now;
 
-final class RejectApplicationTransition extends AbstractApplicationTransition
+final class RejectedApplicationState extends ApplicationState
 {
     public function choices(): array
     {

--- a/app-modules/applications/src/States/TransitionData.php
+++ b/app-modules/applications/src/States/TransitionData.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace He4rt\Applications\Services\Transitions;
+namespace He4rt\Applications\States;
 
 use Carbon\CarbonInterface;
 use He4rt\Applications\Enums\ApplicationStatusEnum;

--- a/app-modules/applications/src/States/WithdrawnApplicationState.php
+++ b/app-modules/applications/src/States/WithdrawnApplicationState.php
@@ -2,12 +2,18 @@
 
 declare(strict_types=1);
 
-namespace He4rt\Applications\Services\Transitions;
+namespace He4rt\Applications\States;
 
 use He4rt\Applications\Enums\ApplicationStatusEnum;
 
-final class OfferDeclinedTransition extends AbstractApplicationTransition
+/**
+ * Handle candidate-initiated or admin-initiated withdrawals.
+ */
+final class WithdrawnApplicationState extends ApplicationState
 {
+    /**
+     * @return array<string,string|null>
+     */
     public function choices(): array
     {
         return [];
@@ -23,7 +29,7 @@ final class OfferDeclinedTransition extends AbstractApplicationTransition
     public function processStep(TransitionData $data): void
     {
         $this->application->update([
-            'status' => ApplicationStatusEnum::OfferDeclined,
+            'status' => ApplicationStatusEnum::Withdrawn,
         ]);
     }
 

--- a/app-modules/applications/tests/Feature/States/ApplicationStateTest.php
+++ b/app-modules/applications/tests/Feature/States/ApplicationStateTest.php
@@ -6,12 +6,12 @@ use He4rt\Applications\Enums\ApplicationStatusEnum;
 use He4rt\Applications\Events\ApplicationStatusChanged;
 use He4rt\Applications\Models\Application;
 use He4rt\Applications\Models\ApplicationStageHistory;
-use He4rt\Applications\Services\Transitions\TransitionData;
+use He4rt\Applications\States\TransitionData;
 use He4rt\Recruitment\Stages\Models\Stage;
 use He4rt\Users\User;
 use Illuminate\Support\Facades\Event;
 
-describe('AbstractApplicationTransition::handle()', function (): void {
+describe('ApplicationState::handle()', function (): void {
     it('creates a stage history record after a valid transition', function (): void {
         $user = User::factory()->create();
         $application = Application::factory()->create([
@@ -24,7 +24,7 @@ describe('AbstractApplicationTransition::handle()', function (): void {
             'to_status' => ApplicationStatusEnum::InReview,
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         expect(ApplicationStageHistory::query()->where('application_id', $application->id)->count())->toBe(1);
 
@@ -46,7 +46,7 @@ describe('AbstractApplicationTransition::handle()', function (): void {
             'notes' => 'Moving to review stage.',
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         $history = ApplicationStageHistory::query()->where('application_id', $application->id)->first();
         expect($history->notes)->toBe('Moving to review stage.');
@@ -66,7 +66,7 @@ describe('AbstractApplicationTransition::handle()', function (): void {
             // Neither to_stage_id nor advance_stage — processStep will throw
         ], $user->id);
 
-        expect(fn () => $application->current_step->handle($data))->toThrow(Exception::class);
+        expect(fn () => $application->current_state->handle($data))->toThrow(Exception::class);
 
         // DB should be untouched
         expect(ApplicationStageHistory::query()->where('application_id', $application->id)->count())->toBe(0);
@@ -85,7 +85,7 @@ describe('AbstractApplicationTransition::handle()', function (): void {
             'to_status' => ApplicationStatusEnum::InReview,
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         Event::assertDispatched(fn (ApplicationStatusChanged $event): bool => $event->application->id === $application->id
             && $event->fromStatus === ApplicationStatusEnum::New->value
@@ -112,7 +112,7 @@ describe('AbstractApplicationTransition::handle()', function (): void {
             'to_stage_id' => $newStage->id,
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         Event::assertNotDispatched(ApplicationStatusChanged::class);
     });
@@ -130,7 +130,7 @@ describe('AbstractApplicationTransition::handle()', function (): void {
             'notes' => 'Test note',
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         Event::assertDispatched(fn (ApplicationStatusChanged $event): bool => $event->by->id === $user->id
             && $event->meta['notes'] === 'Test note');
@@ -155,7 +155,7 @@ describe('AbstractApplicationTransition::handle()', function (): void {
             'to_status' => ApplicationStatusEnum::InReview,
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         expect($state->historyExistedAtDispatch)->toBeTrue();
     });

--- a/app-modules/applications/tests/Feature/States/AutomaticActorTransitionTest.php
+++ b/app-modules/applications/tests/Feature/States/AutomaticActorTransitionTest.php
@@ -6,7 +6,7 @@ use He4rt\Applications\Enums\ApplicationStatusEnum;
 use He4rt\Applications\Enums\RejectionReasonCategoryEnum;
 use He4rt\Applications\Events\ApplicationStatusChanged;
 use He4rt\Applications\Models\Application;
-use He4rt\Applications\Services\Transitions\TransitionData;
+use He4rt\Applications\States\TransitionData;
 use He4rt\Users\User;
 use Illuminate\Support\Facades\Event;
 
@@ -19,7 +19,7 @@ it('performs a New → Rejected transition with a null actor (system)', function
         'rejection_reason_details' => 'Failed: Q1',
     ]);
 
-    $application->current_step->handle($data);
+    $application->current_state->handle($data);
 
     $application->refresh();
 
@@ -40,7 +40,7 @@ it('still dispatches ApplicationStatusChanged with a null actor', function (): v
         'to_status' => ApplicationStatusEnum::Withdrawn,
     ]);
 
-    $application->current_step->handle($data);
+    $application->current_state->handle($data);
 
     Event::assertDispatched(fn (ApplicationStatusChanged $event): bool => ! $event->by instanceof User
         && $event->toStatus === ApplicationStatusEnum::Withdrawn->value);

--- a/app-modules/applications/tests/Feature/States/InProgressApplicationStateTest.php
+++ b/app-modules/applications/tests/Feature/States/InProgressApplicationStateTest.php
@@ -7,23 +7,23 @@ use He4rt\Applications\Enums\RejectionReasonCategoryEnum;
 use He4rt\Applications\Exceptions\InvalidTransitionException;
 use He4rt\Applications\Exceptions\MissingTransitionDataException;
 use He4rt\Applications\Models\Application;
-use He4rt\Applications\Services\Transitions\InProgressTransition;
-use He4rt\Applications\Services\Transitions\TransitionData;
+use He4rt\Applications\States\InProgressApplicationState;
+use He4rt\Applications\States\TransitionData;
 use He4rt\Recruitment\Stages\Models\Stage;
 use He4rt\Users\User;
 use Illuminate\Support\Facades\Date;
 
-describe('InProgressTransition', function (): void {
+describe('InProgressApplicationState', function (): void {
     it('canChange() returns true', function (): void {
         $application = Application::factory()->withStatus(ApplicationStatusEnum::InProgress)->create();
-        $transition = new InProgressTransition($application);
+        $transition = new InProgressApplicationState($application);
 
         expect($transition->canChange())->toBeTrue();
     });
 
     it('choices() contains InProgress, OfferExtended, Rejected and Withdrawn', function (): void {
         $application = Application::factory()->withStatus(ApplicationStatusEnum::InProgress)->create();
-        $transition = new InProgressTransition($application);
+        $transition = new InProgressApplicationState($application);
 
         expect(array_keys($transition->choices()))->toContain(
             ApplicationStatusEnum::InProgress->value,
@@ -55,7 +55,7 @@ describe('InProgressTransition', function (): void {
             'to_stage_id' => $targetStage->id,
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         $application->refresh();
 
@@ -85,7 +85,7 @@ describe('InProgressTransition', function (): void {
             'to_stage_id' => $target->id,
         ], $user->id);
 
-        expect(fn () => $application->current_step->handle($data))
+        expect(fn () => $application->current_state->handle($data))
             ->toThrow(InvalidTransitionException::class);
 
         expect($application->fresh()->current_stage_id)->toBe($current->id);
@@ -116,7 +116,7 @@ describe('InProgressTransition', function (): void {
             'to_stage_id' => $inactive->id,
         ], $user->id);
 
-        expect(fn () => $application->current_step->handle($data))
+        expect(fn () => $application->current_state->handle($data))
             ->toThrow(InvalidTransitionException::class);
 
         expect($application->fresh()->current_stage_id)->toBe($current->id);
@@ -145,7 +145,7 @@ describe('InProgressTransition', function (): void {
             'to_stage_id' => $foreignStage->id,
         ], $user->id);
 
-        expect(fn () => $application->current_step->handle($data))
+        expect(fn () => $application->current_state->handle($data))
             ->toThrow(InvalidTransitionException::class);
 
         expect($application->fresh()->current_stage_id)->toBe($current->id);
@@ -164,7 +164,7 @@ describe('InProgressTransition', function (): void {
             'advance_stage' => true,
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         expect($application->fresh()->current_stage_id)->toBe($stage->id);
     });
@@ -182,7 +182,7 @@ describe('InProgressTransition', function (): void {
             'advance_stage' => true,
         ], $user->id);
 
-        expect(fn () => $application->current_step->handle($data))->toThrow(InvalidTransitionException::class);
+        expect(fn () => $application->current_state->handle($data))->toThrow(InvalidTransitionException::class);
     });
 
     it('InProgress → OfferExtended writes all offer fields', function (): void {
@@ -196,7 +196,7 @@ describe('InProgressTransition', function (): void {
             'offer_response_deadline' => Date::parse('2026-03-08 00:00:00'),
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         $application->refresh();
 
@@ -216,7 +216,7 @@ describe('InProgressTransition', function (): void {
             'to_status' => ApplicationStatusEnum::OfferExtended,
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         expect($application->fresh()->offer_extended_at->isAfter($before))->toBeTrue();
     });
@@ -229,7 +229,7 @@ describe('InProgressTransition', function (): void {
             'to_status' => ApplicationStatusEnum::Rejected,
         ], $user->id);
 
-        expect(fn () => $application->current_step->handle($data))
+        expect(fn () => $application->current_state->handle($data))
             ->toThrow(MissingTransitionDataException::class);
     });
 
@@ -243,7 +243,7 @@ describe('InProgressTransition', function (): void {
             'rejection_reason_details' => 'Not a good cultural fit',
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         $application->refresh();
 
@@ -262,7 +262,7 @@ describe('InProgressTransition', function (): void {
             'to_status' => ApplicationStatusEnum::Withdrawn,
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         expect($application->fresh()->status)->toBe(ApplicationStatusEnum::Withdrawn);
     });
@@ -275,6 +275,6 @@ describe('InProgressTransition', function (): void {
             'to_status' => ApplicationStatusEnum::Hired,
         ], $user->id);
 
-        expect(fn () => $application->current_step->handle($data))->toThrow(InvalidTransitionException::class);
+        expect(fn () => $application->current_state->handle($data))->toThrow(InvalidTransitionException::class);
     });
 });

--- a/app-modules/applications/tests/Feature/States/InReviewApplicationStateTest.php
+++ b/app-modules/applications/tests/Feature/States/InReviewApplicationStateTest.php
@@ -7,22 +7,22 @@ use He4rt\Applications\Enums\RejectionReasonCategoryEnum;
 use He4rt\Applications\Exceptions\InvalidTransitionException;
 use He4rt\Applications\Exceptions\MissingTransitionDataException;
 use He4rt\Applications\Models\Application;
-use He4rt\Applications\Services\Transitions\InReviewTransition;
-use He4rt\Applications\Services\Transitions\TransitionData;
+use He4rt\Applications\States\InReviewApplicationState;
+use He4rt\Applications\States\TransitionData;
 use He4rt\Recruitment\Stages\Models\Stage;
 use He4rt\Users\User;
 
-describe('InReviewTransition', function (): void {
+describe('InReviewApplicationState', function (): void {
     it('canChange() returns true', function (): void {
         $application = Application::factory()->withStatus(ApplicationStatusEnum::InReview)->create();
-        $transition = new InReviewTransition($application);
+        $transition = new InReviewApplicationState($application);
 
         expect($transition->canChange())->toBeTrue();
     });
 
     it('choices() contains InProgress, Rejected and Withdrawn', function (): void {
         $application = Application::factory()->withStatus(ApplicationStatusEnum::InReview)->create();
-        $transition = new InReviewTransition($application);
+        $transition = new InReviewApplicationState($application);
 
         expect(array_keys($transition->choices()))->toContain(
             ApplicationStatusEnum::InProgress->value,
@@ -43,7 +43,7 @@ describe('InReviewTransition', function (): void {
             'to_status' => ApplicationStatusEnum::InProgress,
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         $application->refresh();
 
@@ -64,7 +64,7 @@ describe('InReviewTransition', function (): void {
             'to_stage_id' => $specificStage->id,
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         expect($application->fresh()->current_stage_id)->toBe($specificStage->id);
     });
@@ -77,7 +77,7 @@ describe('InReviewTransition', function (): void {
             'to_status' => ApplicationStatusEnum::Rejected,
         ], $user->id);
 
-        expect(fn () => $application->current_step->handle($data))
+        expect(fn () => $application->current_state->handle($data))
             ->toThrow(MissingTransitionDataException::class);
     });
 
@@ -91,7 +91,7 @@ describe('InReviewTransition', function (): void {
             'rejection_reason_details' => 'Insufficient experience',
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         $application->refresh();
 
@@ -110,7 +110,7 @@ describe('InReviewTransition', function (): void {
             'to_status' => ApplicationStatusEnum::Withdrawn,
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         expect($application->fresh()->status)->toBe(ApplicationStatusEnum::Withdrawn);
     });
@@ -123,7 +123,7 @@ describe('InReviewTransition', function (): void {
             'to_status' => ApplicationStatusEnum::Hired,
         ], $user->id);
 
-        expect(fn () => $application->current_step->handle($data))->toThrow(InvalidTransitionException::class);
+        expect(fn () => $application->current_state->handle($data))->toThrow(InvalidTransitionException::class);
     });
 
     it('rejected_at defaults to now() when not provided', function (): void {
@@ -137,7 +137,7 @@ describe('InReviewTransition', function (): void {
             'rejection_reason_category' => RejectionReasonCategoryEnum::Other,
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         expect($application->fresh()->rejected_at)->not->toBeNull()
             ->and($application->fresh()->rejected_at->isAfter($before))->toBeTrue();

--- a/app-modules/applications/tests/Feature/States/NewApplicationStateTest.php
+++ b/app-modules/applications/tests/Feature/States/NewApplicationStateTest.php
@@ -6,22 +6,22 @@ use He4rt\Applications\Enums\ApplicationStatusEnum;
 use He4rt\Applications\Enums\RejectionReasonCategoryEnum;
 use He4rt\Applications\Exceptions\InvalidTransitionException;
 use He4rt\Applications\Models\Application;
-use He4rt\Applications\Services\Transitions\NewTransition;
-use He4rt\Applications\Services\Transitions\TransitionData;
+use He4rt\Applications\States\NewApplicationState;
+use He4rt\Applications\States\TransitionData;
 use He4rt\Users\User;
 use Illuminate\Support\Facades\Date;
 
-describe('NewTransition', function (): void {
+describe('NewApplicationState', function (): void {
     it('canChange() returns true', function (): void {
         $application = Application::factory()->withStatus(ApplicationStatusEnum::New)->create();
-        $transition = new NewTransition($application);
+        $transition = new NewApplicationState($application);
 
         expect($transition->canChange())->toBeTrue();
     });
 
     it('choices() contains InReview, Rejected and Withdrawn', function (): void {
         $application = Application::factory()->withStatus(ApplicationStatusEnum::New)->create();
-        $transition = new NewTransition($application);
+        $transition = new NewApplicationState($application);
 
         expect(array_keys($transition->choices()))->toContain(
             ApplicationStatusEnum::InReview->value,
@@ -42,7 +42,7 @@ describe('NewTransition', function (): void {
             'to_status' => ApplicationStatusEnum::InReview,
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         $application->refresh();
 
@@ -62,7 +62,7 @@ describe('NewTransition', function (): void {
             'to_status' => ApplicationStatusEnum::InReview,
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         $application->refresh();
 
@@ -78,7 +78,7 @@ describe('NewTransition', function (): void {
             'to_status' => ApplicationStatusEnum::Withdrawn,
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         expect($application->fresh()->status)->toBe(ApplicationStatusEnum::Withdrawn);
     });
@@ -94,7 +94,7 @@ describe('NewTransition', function (): void {
             'rejected_at' => Date::parse('2026-01-15 10:00:00'),
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         $application->refresh();
 
@@ -112,6 +112,6 @@ describe('NewTransition', function (): void {
             'to_status' => ApplicationStatusEnum::Hired,
         ], $user->id);
 
-        expect(fn () => $application->current_step->handle($data))->toThrow(InvalidTransitionException::class);
+        expect(fn () => $application->current_state->handle($data))->toThrow(InvalidTransitionException::class);
     });
 });

--- a/app-modules/applications/tests/Feature/States/OfferAcceptedApplicationStateTest.php
+++ b/app-modules/applications/tests/Feature/States/OfferAcceptedApplicationStateTest.php
@@ -5,21 +5,21 @@ declare(strict_types=1);
 use He4rt\Applications\Enums\ApplicationStatusEnum;
 use He4rt\Applications\Exceptions\InvalidTransitionException;
 use He4rt\Applications\Models\Application;
-use He4rt\Applications\Services\Transitions\OfferAcceptedTransition;
-use He4rt\Applications\Services\Transitions\TransitionData;
+use He4rt\Applications\States\OfferAcceptedApplicationState;
+use He4rt\Applications\States\TransitionData;
 use He4rt\Users\User;
 
-describe('OfferAcceptedTransition', function (): void {
+describe('OfferAcceptedApplicationState', function (): void {
     it('canChange() returns true', function (): void {
         $application = Application::factory()->create(['status' => ApplicationStatusEnum::OfferAccepted]);
-        $transition = new OfferAcceptedTransition($application);
+        $transition = new OfferAcceptedApplicationState($application);
 
         expect($transition->canChange())->toBeTrue();
     });
 
     it('choices() contains Hired and Withdrawn', function (): void {
         $application = Application::factory()->create(['status' => ApplicationStatusEnum::OfferAccepted]);
-        $transition = new OfferAcceptedTransition($application);
+        $transition = new OfferAcceptedApplicationState($application);
 
         expect(array_keys($transition->choices()))->toContain(
             ApplicationStatusEnum::Hired->value,
@@ -37,7 +37,7 @@ describe('OfferAcceptedTransition', function (): void {
             'to_status' => ApplicationStatusEnum::Hired,
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         expect($application->fresh()->status)->toBe(ApplicationStatusEnum::Hired);
     });
@@ -52,7 +52,7 @@ describe('OfferAcceptedTransition', function (): void {
             'to_status' => ApplicationStatusEnum::Rejected,
         ], $user->id);
 
-        expect(fn () => $application->current_step->handle($data))->toThrow(InvalidTransitionException::class);
+        expect(fn () => $application->current_state->handle($data))->toThrow(InvalidTransitionException::class);
     });
 
     it('OfferAccepted → Withdrawn succeeds and is status-only', function (): void {
@@ -66,7 +66,7 @@ describe('OfferAcceptedTransition', function (): void {
             'to_status' => ApplicationStatusEnum::Withdrawn,
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         $fresh = $application->fresh();
         expect($fresh->status)->toBe(ApplicationStatusEnum::Withdrawn)

--- a/app-modules/applications/tests/Feature/States/OfferExtendedApplicationStateTest.php
+++ b/app-modules/applications/tests/Feature/States/OfferExtendedApplicationStateTest.php
@@ -6,22 +6,22 @@ use He4rt\Applications\Enums\ApplicationStatusEnum;
 use He4rt\Applications\Exceptions\InvalidTransitionException;
 use He4rt\Applications\Exceptions\MissingTransitionDataException;
 use He4rt\Applications\Models\Application;
-use He4rt\Applications\Services\Transitions\OfferExtendedTransition;
-use He4rt\Applications\Services\Transitions\TransitionData;
+use He4rt\Applications\States\OfferExtendedApplicationState;
+use He4rt\Applications\States\TransitionData;
 use He4rt\Recruitment\Stages\Models\Stage;
 use He4rt\Users\User;
 
-describe('OfferExtendedTransition', function (): void {
+describe('OfferExtendedApplicationState', function (): void {
     it('canChange() returns true', function (): void {
         $application = Application::factory()->withOffer()->create();
-        $transition = new OfferExtendedTransition($application);
+        $transition = new OfferExtendedApplicationState($application);
 
         expect($transition->canChange())->toBeTrue();
     });
 
     it('choices() contains OfferAccepted, OfferDeclined and Withdrawn', function (): void {
         $application = Application::factory()->withOffer()->create();
-        $transition = new OfferExtendedTransition($application);
+        $transition = new OfferExtendedApplicationState($application);
 
         expect(array_keys($transition->choices()))->toContain(
             ApplicationStatusEnum::OfferAccepted->value,
@@ -39,7 +39,7 @@ describe('OfferExtendedTransition', function (): void {
             'to_status' => ApplicationStatusEnum::OfferAccepted,
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         $fresh = $application->fresh();
         expect($fresh->status)->toBe(ApplicationStatusEnum::OfferAccepted)
@@ -55,7 +55,7 @@ describe('OfferExtendedTransition', function (): void {
             // no to_stage_id — accepting an offer is status-only now
         ], $user->id);
 
-        expect(fn () => $application->current_step->handle($data))
+        expect(fn () => $application->current_state->handle($data))
             ->not->toThrow(MissingTransitionDataException::class);
 
         expect($application->fresh()->status)->toBe(ApplicationStatusEnum::OfferAccepted);
@@ -71,7 +71,7 @@ describe('OfferExtendedTransition', function (): void {
             'to_stage_id' => $stage->id,
         ], $user->id);
 
-        expect(fn () => $application->current_step->handle($data))->not->toThrow(MissingTransitionDataException::class);
+        expect(fn () => $application->current_state->handle($data))->not->toThrow(MissingTransitionDataException::class);
     });
 
     it('OfferExtended → OfferDeclined succeeds without any extra data', function (): void {
@@ -82,7 +82,7 @@ describe('OfferExtendedTransition', function (): void {
             'to_status' => ApplicationStatusEnum::OfferDeclined,
         ], $user->id);
 
-        expect(fn () => $application->current_step->handle($data))->not->toThrow(Exception::class);
+        expect(fn () => $application->current_state->handle($data))->not->toThrow(Exception::class);
     });
 
     it('OfferExtended → Withdrawn succeeds without any extra data', function (): void {
@@ -93,7 +93,7 @@ describe('OfferExtendedTransition', function (): void {
             'to_status' => ApplicationStatusEnum::Withdrawn,
         ], $user->id);
 
-        expect(fn () => $application->current_step->handle($data))->not->toThrow(Exception::class);
+        expect(fn () => $application->current_state->handle($data))->not->toThrow(Exception::class);
     });
 
     it('throws InvalidTransitionException for illegal target status', function (): void {
@@ -104,7 +104,7 @@ describe('OfferExtendedTransition', function (): void {
             'to_status' => ApplicationStatusEnum::Hired,
         ], $user->id);
 
-        expect(fn () => $application->current_step->handle($data))->toThrow(InvalidTransitionException::class);
+        expect(fn () => $application->current_state->handle($data))->toThrow(InvalidTransitionException::class);
     });
 
     it('OfferExtended → OfferAccepted does not overwrite the offer fields (status-only)', function (): void {
@@ -116,7 +116,7 @@ describe('OfferExtendedTransition', function (): void {
             'offer_amount' => 95000.0,
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         expect((float) $application->fresh()->offer_amount)->toBe(50000.0);
     });

--- a/app-modules/applications/tests/Feature/States/RejectedApplicationStateTest.php
+++ b/app-modules/applications/tests/Feature/States/RejectedApplicationStateTest.php
@@ -6,22 +6,22 @@ use He4rt\Applications\Enums\ApplicationStatusEnum;
 use He4rt\Applications\Enums\RejectionReasonCategoryEnum;
 use He4rt\Applications\Exceptions\MissingTransitionDataException;
 use He4rt\Applications\Models\Application;
-use He4rt\Applications\Services\Transitions\RejectApplicationTransition;
-use He4rt\Applications\Services\Transitions\TransitionData;
+use He4rt\Applications\States\RejectedApplicationState;
+use He4rt\Applications\States\TransitionData;
 use He4rt\Users\User;
 use Illuminate\Support\Facades\Date;
 
-describe('RejectApplicationTransition', function (): void {
+describe('RejectedApplicationState', function (): void {
     it('canChange() returns false (terminal state)', function (): void {
         $application = Application::factory()->rejected()->create();
-        $transition = new RejectApplicationTransition($application);
+        $transition = new RejectedApplicationState($application);
 
         expect($transition->canChange())->toBeFalse();
     });
 
     it('choices() returns empty array (terminal state)', function (): void {
         $application = Application::factory()->rejected()->create();
-        $transition = new RejectApplicationTransition($application);
+        $transition = new RejectedApplicationState($application);
 
         expect($transition->choices())->toBe([]);
     });
@@ -39,7 +39,7 @@ describe('RejectApplicationTransition', function (): void {
             'rejected_at' => Date::parse('2026-02-10 14:00:00'),
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         $application->refresh();
 
@@ -60,7 +60,7 @@ describe('RejectApplicationTransition', function (): void {
             // no rejection_reason_category
         ], $user->id);
 
-        expect(fn () => $application->current_step->handle($data))
+        expect(fn () => $application->current_state->handle($data))
             ->toThrow(MissingTransitionDataException::class);
     });
 
@@ -76,7 +76,7 @@ describe('RejectApplicationTransition', function (): void {
             'rejected_at' => Date::parse('2026-01-20 08:30:00'),
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         expect($application->fresh()->rejected_at->toDateTimeString())->toBe('2026-01-20 08:30:00');
     });
@@ -93,7 +93,7 @@ describe('RejectApplicationTransition', function (): void {
             'rejection_reason_category' => RejectionReasonCategoryEnum::Other,
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         expect($application->fresh()->rejected_at->isAfter($before))->toBeTrue();
     });

--- a/app-modules/applications/tests/Feature/States/StageAutoAdvanceTest.php
+++ b/app-modules/applications/tests/Feature/States/StageAutoAdvanceTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use He4rt\Applications\Enums\ApplicationStatusEnum;
 use He4rt\Applications\Models\Application;
-use He4rt\Applications\Services\Transitions\TransitionData;
+use He4rt\Applications\States\TransitionData;
 use He4rt\Recruitment\Stages\Enums\StageTypeEnum;
 use He4rt\Recruitment\Stages\Models\Stage;
 use He4rt\Users\User;
@@ -19,7 +19,7 @@ describe('stage auto-advances to mirror the status on the funnel ends', function
             'offer_amount' => 9500,
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         $fresh = $application->fresh()->load('currentStage');
         expect($fresh->status)->toBe(ApplicationStatusEnum::OfferExtended)
@@ -34,7 +34,7 @@ describe('stage auto-advances to mirror the status on the funnel ends', function
             'to_status' => ApplicationStatusEnum::Hired,
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         $fresh = $application->fresh()->load('currentStage');
         expect($fresh->status)->toBe(ApplicationStatusEnum::Hired)
@@ -50,7 +50,7 @@ describe('stage auto-advances to mirror the status on the funnel ends', function
             'to_status' => ApplicationStatusEnum::Withdrawn,
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         $fresh = $application->fresh();
         expect($fresh->status)->toBe(ApplicationStatusEnum::Withdrawn)
@@ -79,7 +79,7 @@ describe('stage auto-advances to mirror the status on the funnel ends', function
             'offer_amount' => 5000,
         ], $user->id);
 
-        Application::query()->findOrFail($application->id)->current_step->handle($data);
+        Application::query()->findOrFail($application->id)->current_state->handle($data);
 
         expect($application->fresh()->current_stage_id)->toBe($offerStage->id);
     });
@@ -98,7 +98,7 @@ describe('stage auto-advances to mirror the status on the funnel ends', function
             'to_status' => ApplicationStatusEnum::Hired,
         ], $user->id);
 
-        expect(fn () => $reloaded->current_step->handle($data))->not->toThrow(Exception::class);
+        expect(fn () => $reloaded->current_state->handle($data))->not->toThrow(Exception::class);
 
         $fresh = $application->fresh();
         expect($fresh->status)->toBe(ApplicationStatusEnum::Hired)

--- a/app-modules/applications/tests/Feature/States/StageHistoryStatusTest.php
+++ b/app-modules/applications/tests/Feature/States/StageHistoryStatusTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use He4rt\Applications\Enums\ApplicationStatusEnum;
 use He4rt\Applications\Models\Application;
-use He4rt\Applications\Services\Transitions\TransitionData;
+use He4rt\Applications\States\TransitionData;
 use He4rt\Users\User;
 
 describe('stage history records the status transition', function (): void {
@@ -16,7 +16,7 @@ describe('stage history records the status transition', function (): void {
             'to_status' => ApplicationStatusEnum::OfferAccepted,
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         $row = $application->stageHistory()->latest()->first();
 
@@ -33,7 +33,7 @@ describe('stage history records the status transition', function (): void {
             'to_status' => ApplicationStatusEnum::OfferDeclined,
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         $row = $application->stageHistory()->latest()->first();
 

--- a/app-modules/applications/tests/Feature/States/TerminalTransitionsTest.php
+++ b/app-modules/applications/tests/Feature/States/TerminalTransitionsTest.php
@@ -5,23 +5,23 @@ declare(strict_types=1);
 use He4rt\Applications\Enums\ApplicationStatusEnum;
 use He4rt\Applications\Models\Application;
 use He4rt\Applications\Models\ApplicationStageHistory;
-use He4rt\Applications\Services\Transitions\HiredTransition;
-use He4rt\Applications\Services\Transitions\OfferDeclinedTransition;
-use He4rt\Applications\Services\Transitions\TransitionData;
-use He4rt\Applications\Services\Transitions\WithdrawnTransition;
+use He4rt\Applications\States\HiredApplicationState;
+use He4rt\Applications\States\OfferDeclinedApplicationState;
+use He4rt\Applications\States\TransitionData;
+use He4rt\Applications\States\WithdrawnApplicationState;
 use He4rt\Users\User;
 
-describe('HiredTransition', function (): void {
+describe('HiredApplicationState', function (): void {
     it('canChange() returns false (terminal state)', function (): void {
         $application = Application::factory()->create(['status' => ApplicationStatusEnum::Hired]);
-        $transition = new HiredTransition($application);
+        $transition = new HiredApplicationState($application);
 
         expect($transition->canChange())->toBeFalse();
     });
 
     it('choices() returns empty array (terminal state)', function (): void {
         $application = Application::factory()->create(['status' => ApplicationStatusEnum::Hired]);
-        $transition = new HiredTransition($application);
+        $transition = new HiredApplicationState($application);
 
         expect($transition->choices())->toBe([]);
     });
@@ -36,7 +36,7 @@ describe('HiredTransition', function (): void {
             'to_status' => ApplicationStatusEnum::Hired,
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         expect($application->fresh()->status)->toBe(ApplicationStatusEnum::Hired);
     });
@@ -51,23 +51,23 @@ describe('HiredTransition', function (): void {
             'to_status' => ApplicationStatusEnum::Hired,
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         expect(ApplicationStageHistory::query()->where('application_id', $application->id)->count())->toBe(1);
     });
 });
 
-describe('WithdrawnTransition', function (): void {
+describe('WithdrawnApplicationState', function (): void {
     it('canChange() returns false (terminal state)', function (): void {
         $application = Application::factory()->create(['status' => ApplicationStatusEnum::Withdrawn]);
-        $transition = new WithdrawnTransition($application);
+        $transition = new WithdrawnApplicationState($application);
 
         expect($transition->canChange())->toBeFalse();
     });
 
     it('choices() returns empty array (terminal state)', function (): void {
         $application = Application::factory()->create(['status' => ApplicationStatusEnum::Withdrawn]);
-        $transition = new WithdrawnTransition($application);
+        $transition = new WithdrawnApplicationState($application);
 
         expect($transition->choices())->toBe([]);
     });
@@ -82,7 +82,7 @@ describe('WithdrawnTransition', function (): void {
             'to_status' => ApplicationStatusEnum::Withdrawn,
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         expect($application->fresh()->status)->toBe(ApplicationStatusEnum::Withdrawn);
     });
@@ -97,23 +97,23 @@ describe('WithdrawnTransition', function (): void {
             'to_status' => ApplicationStatusEnum::Withdrawn,
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         expect(ApplicationStageHistory::query()->where('application_id', $application->id)->count())->toBe(1);
     });
 });
 
-describe('OfferDeclinedTransition', function (): void {
+describe('OfferDeclinedApplicationState', function (): void {
     it('canChange() returns false (terminal state)', function (): void {
         $application = Application::factory()->create(['status' => ApplicationStatusEnum::OfferDeclined]);
-        $transition = new OfferDeclinedTransition($application);
+        $transition = new OfferDeclinedApplicationState($application);
 
         expect($transition->canChange())->toBeFalse();
     });
 
     it('choices() returns empty array (terminal state)', function (): void {
         $application = Application::factory()->create(['status' => ApplicationStatusEnum::OfferDeclined]);
-        $transition = new OfferDeclinedTransition($application);
+        $transition = new OfferDeclinedApplicationState($application);
 
         expect($transition->choices())->toBe([]);
     });
@@ -128,7 +128,7 @@ describe('OfferDeclinedTransition', function (): void {
             'to_status' => ApplicationStatusEnum::OfferDeclined,
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         expect($application->fresh()->status)->toBe(ApplicationStatusEnum::OfferDeclined);
     });
@@ -143,7 +143,7 @@ describe('OfferDeclinedTransition', function (): void {
             'to_status' => ApplicationStatusEnum::OfferDeclined,
         ], $user->id);
 
-        $application->current_step->handle($data);
+        $application->current_state->handle($data);
 
         expect(ApplicationStageHistory::query()->where('application_id', $application->id)->count())->toBe(1);
     });

--- a/app-modules/applications/tests/Feature/States/TransitionDataTest.php
+++ b/app-modules/applications/tests/Feature/States/TransitionDataTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Carbon\CarbonInterface;
 use He4rt\Applications\Enums\ApplicationStatusEnum;
 use He4rt\Applications\Enums\RejectionReasonCategoryEnum;
-use He4rt\Applications\Services\Transitions\TransitionData;
+use He4rt\Applications\States\TransitionData;
 use He4rt\Users\User;
 use Illuminate\Support\Facades\Date;
 

--- a/app-modules/panel-admin/src/Filament/Resources/Recruitment/Applications/Schemas/ApplicationForm.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Recruitment/Applications/Schemas/ApplicationForm.php
@@ -57,10 +57,10 @@ class ApplicationForm
 
                         Select::make('status')
                             ->label(__('applications::filament.fields.status'))
-                            ->options(fn (Application $record) => $record->current_step->choices())
+                            ->options(fn (Application $record) => $record->current_state->choices())
                             ->default(ApplicationStatusEnum::New)
                             ->required()
-                            ->disabled(fn (Application $record): bool => ! $record->current_step->canChange())
+                            ->disabled(fn (Application $record): bool => ! $record->current_state->canChange())
                             ->reactive()
                             ->live(),
 

--- a/app-modules/panel-organization/src/Filament/Resources/Recruitment/JobRequisitions/Pages/Kanban/Actions/StateTransitionAction.php
+++ b/app-modules/panel-organization/src/Filament/Resources/Recruitment/JobRequisitions/Pages/Kanban/Actions/StateTransitionAction.php
@@ -15,7 +15,7 @@ use Filament\Schemas\Components\Utilities\Get;
 use Filament\Support\Enums\Width;
 use He4rt\Applications\Enums\ApplicationStatusEnum;
 use He4rt\Applications\Models\Application;
-use He4rt\Applications\Services\Transitions\TransitionData;
+use He4rt\Applications\States\TransitionData;
 use He4rt\Feedback\Actions\StoreEvaluationAction;
 use He4rt\Feedback\DTOs\CriteriaScoresDTO;
 use He4rt\Feedback\DTOs\EvaluationDTO;
@@ -37,8 +37,8 @@ class StateTransitionAction extends Action
             ->icon('heroicon-o-play')
             ->extraAttributes(fn () => ['class' => 'w-full'])
             ->modalWidth(Width::FourExtraLarge)
-            ->disabled(fn (Application $record): bool => ! $record->current_step->canChange())
-            ->tooltip(fn (Application $record): ?string => $record->current_step->canChange() ? null : (string) __('applications::filament.actions.change_status.no_transitions_tooltip'))
+            ->disabled(fn (Application $record): bool => ! $record->current_state->canChange())
+            ->tooltip(fn (Application $record): ?string => $record->current_state->canChange() ? null : (string) __('applications::filament.actions.change_status.no_transitions_tooltip'))
             ->schema($this->buildSchema(...))
             ->action($this->processAction(...))
             ->requiresConfirmation();
@@ -66,7 +66,7 @@ class StateTransitionAction extends Action
 
         $userId = auth()->id();
         $transitionData = TransitionData::fromArray($data, $userId !== null ? (string) $userId : null);
-        $record->current_step->handle($transitionData);
+        $record->current_state->handle($transitionData);
 
         Notification::make()
             ->success()
@@ -108,7 +108,7 @@ class StateTransitionAction extends Action
     private function buildSchema(Application $record): array
     {
         $choices = Arr::except(
-            $record->current_step->choices(),
+            $record->current_state->choices(),
             [ApplicationStatusEnum::Rejected->value],
         );
 

--- a/docs/superpowers/specs/2026-06-17-notify-candidate-application-received-design.md
+++ b/docs/superpowers/specs/2026-06-17-notify-candidate-application-received-design.md
@@ -15,7 +15,7 @@ de candidatura (decididas durante o brainstorm — ver §2): **consolidar a cria
 ## 1. Contexto
 
 Hoje **nenhuma** transição da candidatura notifica o candidato — todos os `notify()` das transições
-(`AbstractApplicationTransition` e subclasses) estão vazios. O RH decidiu (respostas de 01/06/2026) que,
+(`ApplicationState` e subclasses) estão vazios. O RH decidiu (respostas de 01/06/2026) que,
 **por ora**, o único momento que gera aviso ao candidato é a **confirmação de candidatura recebida**
 (decisão 3.1), entregue em **dois canais** — painel in-app (`database`) **e** e-mail (decisão 3.2).
 Reprovações **nunca** são notificadas (decisão 3.3), nem as manuais nem a auto-reprovação por knockout.
@@ -26,11 +26,11 @@ quando o RH liberar (ex.: #198 proposta).
 
 ### Correções de premissas da issue (validadas contra o código atual)
 
-| Premissa da issue                         | Realidade no código                                                                                                                                                            | Efeito no design                                            |
-| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------- |
-| "Canal `database` nunca foi usado"        | **Falso.** `MentionedInCommentNotification` já usa `['mail','database']` com `toDatabase()` via `FilamentNotification::make()->...->getDatabaseMessage()`.                     | **Reusamos** o padrão.                                      |
-| "Candidato é `Notifiable`"                | Quem é `Notifiable` é o `User`, não o `Candidate`.                                                                                                                             | Alvo = `$application->candidate->user`.                     |
-| "Disparar via `ApplicationStatusChanged`" | Esse evento só dispara com `fromStatus !== toStatus`. A candidatura **nasce** em `New` — nunca dispara na criação. `NewTransition` modela a **saída** de `New`, não a entrada. | Gatilho = evento de domínio próprio `ApplicationSubmitted`. |
+| Premissa da issue                         | Realidade no código                                                                                                                                                                  | Efeito no design                                            |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------- |
+| "Canal `database` nunca foi usado"        | **Falso.** `MentionedInCommentNotification` já usa `['mail','database']` com `toDatabase()` via `FilamentNotification::make()->...->getDatabaseMessage()`.                           | **Reusamos** o padrão.                                      |
+| "Candidato é `Notifiable`"                | Quem é `Notifiable` é o `User`, não o `Candidate`.                                                                                                                                   | Alvo = `$application->candidate->user`.                     |
+| "Disparar via `ApplicationStatusChanged`" | Esse evento só dispara com `fromStatus !== toStatus`. A candidatura **nasce** em `New` — nunca dispara na criação. `NewApplicationState` modela a **saída** de `New`, não a entrada. | Gatilho = evento de domínio próprio `ApplicationSubmitted`. |
 
 ---
 


### PR DESCRIPTION
## O que é

Uma faxina de nomenclatura no módulo de candidaturas. **Nada de comportamento muda** — só os nomes de algumas classes ficam mais claros e coerentes.

## O problema

O "motor" que controla por quais etapas uma candidatura passa (nova → em análise → entrevista → contratado/recusado) tinha nomes que confundiam:

- A pasta se chamava `Services/`, mas não havia serviço nenhum lá dentro — só esse motor.
- Cada classe terminava em `Transition` (transição), só que cada uma representa, na verdade, um **estado** da candidatura — e não a passagem entre estados. É como chamar "parado", "andando" e "correndo" de "passos": troca a coisa pelo movimento.
- Pior: para se referir ao mesmo conceito, o código usava **quatro palavras diferentes** em lugares diferentes — `Service`, `Transition`, `Action`, `Step`. Quem lia precisava adivinhar que eram tudo a mesma coisa.

## O que foi feito

Unifiquei tudo em uma palavra só: **State** (estado).

- `Services/Transitions/` passou a se chamar `States/`.
- Cada classe agora diz o que é: `NewApplicationState`, `InReviewApplicationState`, `HiredApplicationState`, e assim por diante.
- Usei `NewApplicationState` em vez de só `NewState` porque "novo" sozinho é vago — assim fica claro que é "o estado de uma candidatura nova".
- A única classe que estava com nome de verbo (`RejectApplicationTransition`) entrou no mesmo padrão das outras: `RejectedApplicationState`.

## Tem risco?

Baixo — é renomeação pura, sem mexer em lógica. Para garantir:

- ✅ Os **301 testes** do fluxo continuam passando (o mesmo número de antes da mudança).
- ✅ A análise estática (**PHPStan nível 7**) segue sem nenhum erro.
- ✅ O **histórico do Git** de cada arquivo foi preservado (renomeados via `git mv`, não apagados e recriados).

## Por que vale a pena

Quando alguém for adicionar um novo estado de candidatura no futuro, o padrão é óbvio e auto-explicativo. E ninguém mais precisa decorar que "Service", "Transition", "Action" e "Step" eram, no fim das contas, a mesma coisa.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured internal application state management system for improved code organization and maintainability.

* **Documentation**
  * Updated documentation to reflect current terminology in the application state system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->